### PR TITLE
[Fix] Make all job arguments required fields

### DIFF
--- a/lib/sidekiq_adhoc_job/web/job_presenter.rb
+++ b/lib/sidekiq_adhoc_job/web/job_presenter.rb
@@ -4,7 +4,7 @@ module SidekiqAdhocJob
     class JobPresenter
       include Sidekiq::WebHelpers
 
-      attr_reader :name, :path_name, :queue, :required_args, :optional_args, :has_rest_args, :args
+      attr_reader :name, :path_name, :queue, :has_rest_args, :args
 
       StringUtil ||= ::SidekiqAdhocJob::Utils::String
 

--- a/lib/sidekiq_adhoc_job/web/locales/en.yml
+++ b/lib/sidekiq_adhoc_job/web/locales/en.yml
@@ -1,11 +1,10 @@
 en:
   adhoc_jobs: Adhoc Jobs
   adhoc_jobs_actions: Actions
+  adhoc_jobs_arguments: Required Arguments
   adhoc_jobs_go_back: Go Back
   adhoc_jobs_has_rest_arguments: Has Rest Arguments
   adhoc_jobs_name: Job Name
-  adhoc_jobs_optional_arguments: Optional Arguments
   adhoc_jobs_queue: Job Queue
-  adhoc_jobs_required_arguments: Required Arguments
   adhoc_jobs_run_job: Run Job
   adhoc_jobs_view_job: View Job

--- a/lib/sidekiq_adhoc_job/web/templates/jobs/index.html.erb
+++ b/lib/sidekiq_adhoc_job/web/templates/jobs/index.html.erb
@@ -6,8 +6,7 @@
       <tr>
         <th><%= t('adhoc_jobs_name') %></th>
         <th><%= t('adhoc_jobs_queue') %></th>
-        <th><%= t('adhoc_jobs_required_arguments') %></th>
-        <th><%= t('adhoc_jobs_optional_arguments') %></th>
+        <th><%= t('adhoc_jobs_arguments') %></th>
         <th><%= t('adhoc_jobs_has_rest_arguments') %></th>
         <th><%= t('adhoc_jobs_actions') %></th>
       </tr>
@@ -18,8 +17,7 @@
         <tr>
           <td><%= job.name %></td>
           <td><%= job.queue %></td>
-          <td><%= job.required_args.join(', ') %></td>
-          <td><%= job.optional_args.join(', ') %></td>
+          <td><%= job.args.join(', ') %></td>
           <td><%= job.has_rest_args %></td>
           <td class="text-center">
             <a class="btn btn-warn btn-xs" href="<%= root_path %>adhoc-jobs/<%= URI.escape(job.path_name) %>">

--- a/lib/sidekiq_adhoc_job/web/templates/jobs/show.html.erb
+++ b/lib/sidekiq_adhoc_job/web/templates/jobs/show.html.erb
@@ -5,19 +5,11 @@
   <% if @presented_job.args.empty? && !@presented_job.has_rest_args %>
     <p>No job arguments</p>
   <% else %>
-    <% @presented_job.required_args.each do |arg| %>
+    <% @presented_job.args.each do |arg| %>
       <div class="form-group row">
         <label class="col-sm-2 col-form-label" for="<%= arg %>">*<%= arg %>:</label>
         <div class="col-sm-4">
           <input class="form-control" type="text" name="<%= arg %>" id="<%= arg %>" required/>
-        </div>
-      </div>
-    <% end %>
-    <% @presented_job.optional_args.each do |arg| %>
-      <div class="form-group row">
-        <label class="col-sm-2 col-form-label" for="<%= arg %>"><%= arg %>:</label>
-        <div class="col-sm-4">
-          <input class="form-control" type="text" name="<%= arg %>" id="<%= arg %>"/>
         </div>
       </div>
     <% end %>

--- a/spec/sidekiq_adhoc_job/requests/jobs/index_spec.rb
+++ b/spec/sidekiq_adhoc_job/requests/jobs/index_spec.rb
@@ -20,8 +20,7 @@ RSpec.describe 'GET /adhoc_jobs' do
       <tr>
         <td>SidekiqAdhocJob::Test::DummyWorker</td>
         <td>dummy</td>
-        <td>id, overwrite</td>
-        <td>retry_job, retries, interval</td>
+        <td>id, overwrite, retry_job, retries, interval</td>
         <td>false</td>
         <td class="text-center">
           <a class="btn btn-warn btn-xs" href="/adhoc-jobs/sidekiq_adhoc_job_test_dummy_worker">

--- a/spec/sidekiq_adhoc_job/requests/jobs/show_spec.rb
+++ b/spec/sidekiq_adhoc_job/requests/jobs/show_spec.rb
@@ -34,27 +34,22 @@ RSpec.describe 'GET /adhoc_jobs/:name' do
             <input class="form-control" type="text" name="overwrite" id="overwrite" required/>
           </div>
         </div>
-        HTML
-      ))
-
-      expect(response_body).to include(compact_html(
-        <<~HTML
         <div class="form-group row">
-          <label class="col-sm-2 col-form-label" for="retry_job">retry_job:</label>
+          <label class="col-sm-2 col-form-label" for="retry_job">*retry_job:</label>
           <div class="col-sm-4">
-            <input class="form-control" type="text" name="retry_job" id="retry_job"/>
+            <input class="form-control" type="text" name="retry_job" id="retry_job" required/>
           </div>
         </div>
         <div class="form-group row">
-          <label class="col-sm-2 col-form-label" for="retries">retries:</label>
+          <label class="col-sm-2 col-form-label" for="retries">*retries:</label>
           <div class="col-sm-4">
-            <input class="form-control" type="text" name="retries" id="retries"/>
+            <input class="form-control" type="text" name="retries" id="retries" required/>
           </div>
         </div>
         <div class="form-group row">
-          <label class="col-sm-2 col-form-label" for="interval">interval:</label>
+          <label class="col-sm-2 col-form-label" for="interval">*interval:</label>
           <div class="col-sm-4">
-            <input class="form-control" type="text" name="interval" id="interval"/>
+            <input class="form-control" type="text" name="interval" id="interval" required/>
           </div>
         </div>
         HTML

--- a/spec/sidekiq_adhoc_job/web/job_presenter_spec.rb
+++ b/spec/sidekiq_adhoc_job/web/job_presenter_spec.rb
@@ -20,8 +20,6 @@ RSpec.describe SidekiqAdhocJob::Web::JobPresenter do
         expect(job_presenter.path_name).to eq 'sidekiq_adhoc_job_test_dummy_worker'
         expect(job_presenter.queue).to eq 'dummy'
         expect(job_presenter.args).to eq %i(id overwrite retry_job retries interval)
-        expect(job_presenter.required_args).to eq %i(id overwrite)
-        expect(job_presenter.optional_args).to eq %i(retry_job retries interval)
         expect(job_presenter.has_rest_args).to eq false
 
         job_presenter = subject.find('sidekiq_adhoc_job_test_namespaced_worker')
@@ -29,8 +27,6 @@ RSpec.describe SidekiqAdhocJob::Web::JobPresenter do
         expect(job_presenter.path_name).to eq 'sidekiq_adhoc_job_test_namespaced_worker'
         expect(job_presenter.queue).to eq 'dummy'
         expect(job_presenter.args).to eq %i()
-        expect(job_presenter.required_args).to eq %i()
-        expect(job_presenter.optional_args).to eq %i()
         expect(job_presenter.has_rest_args).to eq false
 
         job_presenter = subject.find('sidekiq_adhoc_job_test_worker_nested_namespaced_worker')
@@ -38,8 +34,6 @@ RSpec.describe SidekiqAdhocJob::Web::JobPresenter do
         expect(job_presenter.path_name).to eq 'sidekiq_adhoc_job_test_worker_nested_namespaced_worker'
         expect(job_presenter.queue).to eq 'dummy'
         expect(job_presenter.args).to eq %i()
-        expect(job_presenter.required_args).to eq %i()
-        expect(job_presenter.optional_args).to eq %i()
         expect(job_presenter.has_rest_args).to eq false
 
         job_presenter = subject.find('sidekiq_adhoc_job_test_dummy_rest_args_worker')
@@ -47,8 +41,6 @@ RSpec.describe SidekiqAdhocJob::Web::JobPresenter do
         expect(job_presenter.path_name).to eq 'sidekiq_adhoc_job_test_dummy_rest_args_worker'
         expect(job_presenter.queue).to eq 'dummy'
         expect(job_presenter.args).to eq %i(id)
-        expect(job_presenter.required_args).to eq %i(id)
-        expect(job_presenter.optional_args).to eq %i()
         expect(job_presenter.has_rest_args).to eq true
       end
     end


### PR DESCRIPTION
Due to it being impossible (or at least no known easy ways) to find out the default values of optional arguments at run time, we must accept all argument values from the user to trigger the job.