### PR TITLE
Simplify WorkerClassesLoader implementation to avoid const_get() usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,4 @@ SidekiqAdhocJob.init
 
 Options:
 
-- `module_names`: takes in a list of module names that include the worker classes to be loaded, required
-
-Without first configuring, it will raise `SidekiqAdhocJob::InvalidConfigurationError` when `SidekiqAdhocJob.init` is called.
+- `module_names`: takes in a list of module names that include the worker classes to be loaded. When not provided, or an empty list is provided, *ALL* worker classes loaded by your app will be included.

--- a/lib/sidekiq_adhoc_job.rb
+++ b/lib/sidekiq_adhoc_job.rb
@@ -34,10 +34,6 @@ module SidekiqAdhocJob
       @module_names = []
     end
 
-    def configured?
-      !@module_names.empty?
-    end
-
     def module_names
       Array(@module_names).map(&:to_s)
     end

--- a/lib/sidekiq_adhoc_job.rb
+++ b/lib/sidekiq_adhoc_job.rb
@@ -41,6 +41,10 @@ module SidekiqAdhocJob
     def configured?
       !@module_names.empty?
     end
+
+    def module_names
+      Array(@module_names).map(&:to_s)
+    end
   end
 
 end

--- a/lib/sidekiq_adhoc_job.rb
+++ b/lib/sidekiq_adhoc_job.rb
@@ -10,8 +10,6 @@ require 'sidekiq_adhoc_job/web'
 
 module SidekiqAdhocJob
 
-  InvalidConfigurationError ||= Class.new(RuntimeError)
-
   def self.configure
     @_config = Configuration.new
     yield @_config
@@ -22,8 +20,6 @@ module SidekiqAdhocJob
   end
 
   def self.init
-    raise InvalidConfigurationError, 'Must configure before init' unless @_config&.configured?
-
     SidekiqAdhocJob::WorkerClassesLoader.load(@_config.module_names)
 
     Sidekiq::Web.register(SidekiqAdhocJob::Web)

--- a/lib/sidekiq_adhoc_job/worker_classes_loader.rb
+++ b/lib/sidekiq_adhoc_job/worker_classes_loader.rb
@@ -29,7 +29,7 @@ module SidekiqAdhocJob
           allowed_parent_names = allowlist.map(&:to_s)
 
           # allow any workers
-          return true if allowed_parent_names.empty? || allowed_parent_names.include?("Module")
+          return true if allowed_parent_names.empty? || allowed_parent_names.include?('Module')
 
           allowed_parent_names.any? { |prefix| class_name.start_with?(prefix) }
         end

--- a/lib/sidekiq_adhoc_job/worker_classes_loader.rb
+++ b/lib/sidekiq_adhoc_job/worker_classes_loader.rb
@@ -2,42 +2,40 @@ module SidekiqAdhocJob
   class WorkerClassesLoader
     @_worker_klasses = {}
 
-    module ClassMethods
-      def load(module_names)
-        ObjectSpace.each_object(Class).each do |klass|
-          if worker_class?(klass) && module_parent_name?(klass.name, allowlist: module_names)
-            @_worker_klasses[worker_path_name(klass.name)] = klass
-          end
+    def self.load(module_names)
+      ObjectSpace.each_object(Class).each do |klass|
+        if worker_class?(klass) && allowed_namespace?(klass.name, allowlist: module_names)
+          @_worker_klasses[worker_path_name(klass.name)] = klass
         end
       end
-
-      def worker_klasses
-        @_worker_klasses
-      end
-
-      def find_worker_klass(path_name)
-        @_worker_klasses[path_name]
-      end
-
-      private
-
-        def worker_class?(klass)
-          klass.included_modules.include?(Sidekiq::Worker)
-        end
-
-        def module_parent_name?(class_name, allowlist:)
-          allowed_parent_names = allowlist.map(&:to_s)
-
-          # allow any workers
-          return true if allowed_parent_names.empty? || allowed_parent_names.include?('Module')
-
-          allowed_parent_names.any? { |prefix| class_name.start_with?(prefix) }
-        end
-
-        def worker_path_name(worker_name)
-          Utils::String.underscore(worker_name).gsub('/', '_')
-        end
     end
-    extend ClassMethods
+
+    def self.worker_klasses
+      @_worker_klasses
+    end
+
+    def self.find_worker_klass(path_name)
+      @_worker_klasses[path_name]
+    end
+
+    def self.worker_class?(klass)
+      klass.included_modules.include?(Sidekiq::Worker)
+    end
+    private_class_method :worker_class?
+
+    def self.allowed_namespace?(class_name, allowlist:)
+      allowed_namespaces = allowlist.map(&:to_s)
+
+      # allow any workers
+      return true if allowed_namespaces.empty? || allowed_namespaces.include?('Module')
+
+      allowed_namespaces.any? { |prefix| class_name.start_with?(prefix) }
+    end
+    private_class_method :allowed_namespace?
+
+    def self.worker_path_name(worker_name)
+      Utils::String.underscore(worker_name).gsub('/', '_')
+    end
+    private_class_method :worker_path_name
   end
 end

--- a/lib/sidekiq_adhoc_job/worker_classes_loader.rb
+++ b/lib/sidekiq_adhoc_job/worker_classes_loader.rb
@@ -3,9 +3,9 @@ module SidekiqAdhocJob
     @_worker_klasses = {}
 
     module ClassMethods
-      def load(module_parent_names)
+      def load(module_names)
         ObjectSpace.each_object(Class).each do |klass|
-          if worker_class?(klass) && match_module_parent_name?(klass.name, allowlist: module_parent_names)
+          if worker_class?(klass) && module_parent_name?(klass.name, allowlist: module_names)
             @_worker_klasses[worker_path_name(klass.name)] = klass
           end
         end
@@ -25,9 +25,10 @@ module SidekiqAdhocJob
           klass.included_modules.include?(Sidekiq::Worker)
         end
 
-        def match_module_parent_name?(class_name, allowlist:)
+        def module_parent_name?(class_name, allowlist:)
           allowed_parent_names = allowlist.map(&:to_s)
 
+          # allow any workers
           return true if allowed_parent_names.empty? || allowed_parent_names.include?("Module")
 
           allowed_parent_names.any? { |prefix| class_name.start_with?(prefix) }

--- a/lib/sidekiq_adhoc_job/worker_classes_loader.rb
+++ b/lib/sidekiq_adhoc_job/worker_classes_loader.rb
@@ -24,12 +24,9 @@ module SidekiqAdhocJob
     private_class_method :worker_class?
 
     def self.allowed_namespace?(class_name, allowlist:)
-      allowed_namespaces = allowlist.map(&:to_s)
+      return true if allowlist.empty? || allowlist.include?('Module') # allow any namespace
 
-      # allow any workers
-      return true if allowed_namespaces.empty? || allowed_namespaces.include?('Module')
-
-      allowed_namespaces.any? { |prefix| class_name.start_with?(prefix) }
+      allowlist.any? { |prefix| class_name.start_with?(prefix) }
     end
     private_class_method :allowed_namespace?
 

--- a/sidekiq_adhoc_job.gemspec
+++ b/sidekiq_adhoc_job.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.6.0'
 
   spec.add_development_dependency 'pry'
-  spec.add_development_dependency 'bundler', '~> 2.0.1'
+  spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake', '~> 12.3.2'
   spec.add_development_dependency 'rspec', '~> 3.8.0'
   spec.add_development_dependency 'rack-test', '~> 1.1.0'

--- a/spec/sidekiq_adhoc_job_spec.rb
+++ b/spec/sidekiq_adhoc_job_spec.rb
@@ -26,12 +26,6 @@ RSpec.describe SidekiqAdhocJob do
   end
 
   describe '.init' do
-    context 'without configure first' do
-      it 'raises error' do
-        expect { subject.init }.to raise_error(SidekiqAdhocJob::InvalidConfigurationError)
-      end
-    end
-
     context 'configure first' do
       it 'loads worker files and adds web extension' do
         subject.configure do |config|

--- a/spec/sidekiq_adhoc_job_spec.rb
+++ b/spec/sidekiq_adhoc_job_spec.rb
@@ -57,6 +57,18 @@ RSpec.describe SidekiqAdhocJob do
           ]
         )
       end
+
+      it 'transforms module names properly' do
+        subject.configure do |config|
+          config.module_names = [:'SidekiqAdhocJob::Test', :'SidekiqAdhocJob::OtherTest', :'SidekiqAdhocJob::Test::Worker']
+        end
+
+        expect(subject.config.module_names).to eq [
+          'SidekiqAdhocJob::Test',
+          'SidekiqAdhocJob::OtherTest',
+          'SidekiqAdhocJob::Test::Worker'
+        ]
+      end
     end
   end
 end

--- a/spec/sidekiq_adhoc_job_spec.rb
+++ b/spec/sidekiq_adhoc_job_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe SidekiqAdhocJob do
         )
       end
 
-      it 'transforms module names properly' do
+      it 'formats module names properly' do
         subject.configure do |config|
           config.module_names = [:'SidekiqAdhocJob::Test', :'SidekiqAdhocJob::OtherTest', :'SidekiqAdhocJob::Test::Worker']
         end


### PR DESCRIPTION
# Background

In our app, we need to load worker classes without namespace or parent module e.g. `FooWorker`. 

To achieve this, we configure SidekiqAdhocJob like this:

```ruby
SidekiqAdhocJob.configure do |config|
  config.module_names = [:'Module']
end
```

When using it with Ruby 2.6, we get lots of ruby deprecation warnings like this:

```
ruby/2.6.0/gems/sidekiq_adhoc_job-0.1.5/lib/sidekiq_adhoc_job/utils/string.rb:73: warning: constant ::Fixnum is deprecated
```

The warning is caused `#const_get()` usage in `WorkerClassesLoader`.

# Proposed Solution

This PR proposes an alternate way to implement `WorkerClassesLoader`. 

It uses `ObjectSpace.each_object` to find worker classes, avoid `#const_get()`, hence will stop the deprecation warnings.

This approach also makes the implementation slightly simpler.

Let me know what you think? 😺 