### PR TITLE
Feature/rails application job support

### DIFF
--- a/lib/sidekiq_adhoc_job.rb
+++ b/lib/sidekiq_adhoc_job.rb
@@ -16,6 +16,7 @@ module SidekiqAdhocJob
   module Strategies
     autoload :Default, 'sidekiq_adhoc_job/strategies/default'
     autoload :ActiveJob, 'sidekiq_adhoc_job/strategies/active_job'
+    autoload :RailsApplicationJob, 'sidekiq_adhoc_job/strategies/rails_application_job'
   end
 
   def self.configure

--- a/lib/sidekiq_adhoc_job/strategies/rails_application_job.rb
+++ b/lib/sidekiq_adhoc_job/strategies/rails_application_job.rb
@@ -1,0 +1,19 @@
+module SidekiqAdhocJob
+  module Strategies
+    class RailsApplicationJob
+      include SidekiqAdhocJob::Strategy
+
+      def worker_class?(klass)
+        klass.superclass&.name == 'ApplicationJob'
+      end
+
+      def get_queue_name(klass_name)
+        klass_name.queue_name
+      end
+
+      def perform_async(klass, *params)
+        klass.perform_later(*params)
+      end
+    end
+  end
+end

--- a/lib/sidekiq_adhoc_job/web/templates/jobs/show.html.erb
+++ b/lib/sidekiq_adhoc_job/web/templates/jobs/show.html.erb
@@ -25,9 +25,9 @@
     <% end %>
     <% if @presented_job.has_rest_args %>
       <div class="form-group row">
-        <label class="col-sm-2 col-form-label" for="rest_args">*Rest arguments (please provide a json string representing the arguments):</label>
+        <label class="col-sm-2 col-form-label" for="rest_args">Rest arguments (please provide a json string representing the arguments):</label>
         <div class="col-sm-4">
-          <input class="form-control" type="text" name="rest_args" id="rest_args" required/>
+          <input class="form-control" type="text" name="rest_args" id="rest_args"/>
         </div>
       </div>
     <% end %>

--- a/sidekiq_adhoc_job.gemspec
+++ b/sidekiq_adhoc_job.gemspec
@@ -25,14 +25,14 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib/sidekiq_adhoc_job', 'lib']
 
-  spec.required_ruby_version = '>= 2.6.0'
+  spec.required_ruby_version = '~> 2.6'
 
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake', '~> 12.3.2'
-  spec.add_development_dependency 'rspec', '~> 3.8.0'
+  spec.add_development_dependency 'rspec', '~> 3.10.0'
   spec.add_development_dependency 'rack-test', '~> 1.1.0'
-  spec.add_development_dependency 'mock_redis', '~> 0.20.0'
+  spec.add_development_dependency 'mock_redis', '~> 0.26.0'
 
-  spec.add_runtime_dependency 'sidekiq', '>= 5.2.7'
+  spec.add_runtime_dependency 'sidekiq', '~> 5'
 end

--- a/spec/sidekiq_adhoc_job/requests/jobs/show_spec.rb
+++ b/spec/sidekiq_adhoc_job/requests/jobs/show_spec.rb
@@ -97,9 +97,9 @@ RSpec.describe 'GET /adhoc_jobs/:name' do
       expect(response_body).to include(compact_html(
         <<~HTML
         <div class="form-group row">
-          <label class="col-sm-2 col-form-label" for="rest_args">*Rest arguments (please provide a json string representing the arguments):</label>
+          <label class="col-sm-2 col-form-label" for="rest_args">Rest arguments (please provide a json string representing the arguments):</label>
           <div class="col-sm-4">
-            <input class="form-control" type="text" name="rest_args" id="rest_args" required/>
+            <input class="form-control" type="text" name="rest_args" id="rest_args"/>
           </div>
         </div>
         HTML

--- a/spec/sidekiq_adhoc_job_spec.rb
+++ b/spec/sidekiq_adhoc_job_spec.rb
@@ -83,5 +83,24 @@ RSpec.describe SidekiqAdhocJob do
         )
       end
     end
+
+    context 'different strategy: rails_application_job' do
+      it 'loads worker files and adds web extension' do
+        subject.configure do |config|
+          config.module_names = [:'SidekiqAdhocJob::RailsApplicationJobTest']
+          config.strategy_name = :rails_application_job
+        end
+
+        expect(Sidekiq::Web).to receive(:register).with(SidekiqAdhocJob::Web)
+
+        subject.init
+
+        expect(SidekiqAdhocJob::WorkerClassesLoader.worker_klasses.values).to match_array(
+          [
+            SidekiqAdhocJob::RailsApplicationJobTest::DummyApplicationJob
+          ]
+        )
+      end
+    end
   end
 end

--- a/spec/support/fixtures/workers/dummy_application_job.rb
+++ b/spec/support/fixtures/workers/dummy_application_job.rb
@@ -1,0 +1,8 @@
+class ApplicationJob; end
+
+module SidekiqAdhocJob
+  module RailsApplicationJobTest
+    class DummyApplicationJob < ApplicationJob
+    end
+  end
+end


### PR DESCRIPTION
# Dependencies version update

- ruby: constraint to < 2.7.x, more work required to check for 2.7.x compatibility
- sidekiq: constraint to < 5, more work required to check for 6 compatibility
- rspec: update to latest 3.10.0
- mock_redis: update to latest 0.26.0

# Web UI

Temporarily remove required constraint for rest arguments in the Web UI. This is to solve the issue when using the gem with Rails Application Job. Because `ActiveJob::Base` defines abstract method `#perform(*)`, and `ClassInspector` always look up the ancestors chain and use the parameters defined by the highest ancestor in the chain, when the job implements `#perform` with no argument, it ends up using the `ActiveJob::Base#perform` arguments list, and asks for rest arguments.

Permanent fix for this problem welcome.

# Rails ApplicationJob strategy

Currently the gem supports jobs inheriting `ActiveJob::Base`. However, newer Rails projects always create an `ApplicationJob` wrapper, so a new strategy is created to support this out-of-the-box without custom strategy.