### PR TITLE
Upgrade dependency version to support Sidekiq 6

### DIFF
--- a/sidekiq_adhoc_job.gemspec
+++ b/sidekiq_adhoc_job.gemspec
@@ -34,5 +34,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rack-test', '~> 1.1.0'
   spec.add_development_dependency 'mock_redis', '~> 0.26.0'
 
-  spec.add_runtime_dependency 'sidekiq', '~> 5'
+  spec.add_runtime_dependency 'sidekiq', '< 7'
 end


### PR DESCRIPTION
This PR is based on https://github.com/gohkhoonhiang/sidekiq_adhoc_job/pull/14.

# Dependencies version update
- sidekiq: constraint to < 7 to support Sidekiq 6

# Note

As mentioned in [Sidekiq 6 upgrade note](https://github.com/mperham/sidekiq/blob/master/6.0-Upgrade.md), Sidekiq 6 has major breaking changes. As such, it is advisable that user of `sidekiq_adhoc_job` test carefully when upgrading to the release  supporting Sidekiq 6 (temporarily set to be release 1.0.0).