### PR TITLE
[Fix #21] Ensure class inspector inspects the method owned by the class being inspected

### DIFF
--- a/lib/sidekiq_adhoc_job/utils/class_inspector.rb
+++ b/lib/sidekiq_adhoc_job/utils/class_inspector.rb
@@ -40,7 +40,7 @@ module SidekiqAdhocJob
       end
 
       def klass_method(method)
-        return method unless method.super_method
+        return method if method.owner == klass_name
 
         klass_method(method.super_method)
       end

--- a/spec/sidekiq_adhoc_job/utils/class_inspector_spec.rb
+++ b/spec/sidekiq_adhoc_job/utils/class_inspector_spec.rb
@@ -14,11 +14,24 @@ RSpec.describe SidekiqAdhocJob::Utils::ClassInspector do
     end
   end
 
-  context "with a inspecting a method that has been prepended" do
+  context "with a method that has been prepended" do
     let(:klass) { SidekiqAdhocJob::Test::PrependedWorker }
 
     describe "#parameters" do
       it "returns the parameters of the original method" do
+        expect(inspector.parameters(:perform)).to eq({
+          opt: [:retry_job, :retries, :interval],
+          req: [:id, :overwrite]
+        })
+      end
+    end
+  end
+
+  context "with a method that is both prepended and inherited" do
+    let(:klass) { SidekiqAdhocJob::Test::PrependedAndInheritedWorker }
+
+    describe "#parameters" do
+      it "returns the parameters of the method on the target class" do
         expect(inspector.parameters(:perform)).to eq({
           opt: [:retry_job, :retries, :interval],
           req: [:id, :overwrite]

--- a/spec/sidekiq_adhoc_job/utils/class_inspector_spec.rb
+++ b/spec/sidekiq_adhoc_job/utils/class_inspector_spec.rb
@@ -1,0 +1,29 @@
+require_relative "../../../lib/sidekiq_adhoc_job/utils/class_inspector"
+
+RSpec.describe SidekiqAdhocJob::Utils::ClassInspector do
+  subject(:inspector) { described_class.new(klass) }
+
+  let(:klass) { SidekiqAdhocJob::Test::DummyWorker }
+
+  describe "#parameters" do
+    it do
+      expect(inspector.parameters(:perform)).to eq({
+        opt: [:retry_job, :retries, :interval, :name, :options],
+        req: [:id, :overwrite]
+      })
+    end
+  end
+
+  context "with a inspecting a method that has been prepended" do
+    let(:klass) { SidekiqAdhocJob::Test::PrependedWorker }
+
+    describe "#parameters" do
+      it "returns the parameters of the original method" do
+        expect(inspector.parameters(:perform)).to eq({
+          opt: [:retry_job, :retries, :interval],
+          req: [:id, :overwrite]
+        })
+      end
+    end
+  end
+end

--- a/spec/sidekiq_adhoc_job/web/job_presenter_spec.rb
+++ b/spec/sidekiq_adhoc_job/web/job_presenter_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe SidekiqAdhocJob::Web::JobPresenter do
   describe '.build_collection' do
     it 'returns all available job presenters' do
       job_presenters = subject.build_collection
-      expect(job_presenters.count).to eq 9
+      expect(job_presenters.count).to eq 10
     end
   end
 

--- a/spec/sidekiq_adhoc_job_spec.rb
+++ b/spec/sidekiq_adhoc_job_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe SidekiqAdhocJob do
             SidekiqAdhocJob::Test::DummyWorker,
             SidekiqAdhocJob::Test::NamespacedWorker,
             SidekiqAdhocJob::Test::NestedPrependedWorker,
+            SidekiqAdhocJob::Test::PrependedAndInheritedWorker,
             SidekiqAdhocJob::Test::PrependedWorker,
             SidekiqAdhocJob::Test::Worker::NestedNamespacedWorker,
             SidekiqAdhocJob::Test::SampleCSVWorker,

--- a/spec/support/fixtures/workers/prepended_and_inherited_worker.rb
+++ b/spec/support/fixtures/workers/prepended_and_inherited_worker.rb
@@ -1,0 +1,29 @@
+require 'sidekiq'
+
+module SidekiqAdhocJob
+  module Test
+    module LogArgs
+      def perform(*args)
+        puts args
+        super(*args)
+      end
+    end
+
+    module ParentArgs
+      def perform(*args)
+      end
+    end
+
+    class PrependedAndInheritedWorker
+      prepend LogArgs
+      include ParentArgs
+      include Sidekiq::Worker
+
+      sidekiq_options queue: 'dummy'
+
+      def perform(id, overwrite, retry_job = true, retries = 5, interval = 1.5)
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
### Background

The class inspector has a mechanism by which it can bypass a prepended method when inspected using `#parameters`. This works well, but once the mechanism reaches the inspected class, it keeps looking up the ancestor chain. This means that if the same method (usually `#perform`) was also inherited, it will march past the concrete job class being inspected.

Assume in the below ancestor chain, all three implement `#perform`. A class inspector set up to inspect `ConcreteWorker` would end up inspecting the `ParentWorker` instead.

```
[PrependedModule, ConcreteWorker, ParentWorker]
                                  ^ Inspector ends up here. (Too far.)
```

In particular, this causes issues with ActiveJob, since all concrete jobs inherit `#perform` from `ActiveJob::Execution`.

### Impact

When using ActiveJob, all jobs will be shown to have rest arguments only (since this is what `ActiveJob::Execution#perform` accepts.)

<img width="758" alt="Screenshot 2021-07-09 at 11 54 22 AM" src="https://user-images.githubusercontent.com/5259935/125021010-6a754880-e0ac-11eb-8fbb-38cf6b4975b7.png">

### How does this fix it?

The fix is a simple change of the condition on which the inspector tells whether to continue up the ancestor chain. Previously it would do so in the presence of a `#super_method`. With this change it will continue if the owner of the class is not the class being inspected.

```
[PrependedModule, ConcreteWorker, ParentWorker]
                  ^ Inspector now ends up here. (Just right.)
```

If there is no prepended module, that will be on the first iteration. If there is one or more prepended modules, that will be once all the prepended methods are passed and the inspected class is reached.