### PR TITLE
Support kwargs input

### DIFF
--- a/lib/sidekiq_adhoc_job/services/schedule_adhoc_job.rb
+++ b/lib/sidekiq_adhoc_job/services/schedule_adhoc_job.rb
@@ -10,27 +10,42 @@ module SidekiqAdhocJob
       end
       @worker_klass = WorkerClassesLoader.find_worker_klass(job_name)
       @worker_klass_inspector = Utils::ClassInspector.new(worker_klass)
-      @allowed_params = worker_klass_inspector.required_parameters(:perform) + worker_klass_inspector.optional_parameters(:perform)
 
       parse_params
     end
 
     def call
-      SidekiqAdhocJob.config.strategy.perform_async(worker_klass, *worker_params)
+      SidekiqAdhocJob.config.strategy.perform_async(worker_klass, *worker_positional_params, **worker_keyword_params)
     end
 
     private
 
-    attr_reader :request_params, :worker_klass, :worker_klass_inspector,
-                :allowed_params, :worker_params
+    attr_reader :request_params, :worker_klass, :worker_klass_inspector, :worker_positional_params, :worker_keyword_params
 
     def parse_params
-      @worker_params = allowed_params
+      @worker_positional_params = positional_params
         .reject { |key| request_params[key].empty? }
         .map { |key| StringUtil.parse(request_params[key], symbolize: true) }
+      @worker_keyword_params = keyword_params
+        .each_with_object({}) { |key, obj| obj[key.to_sym] = request_params[key] }
+        .compact
       if !!request_params[:rest_args] && !request_params[:rest_args].empty?
-        @worker_params << StringUtil.parse_json(request_params[:rest_args].strip, symbolize: true)
+        @worker_positional_params << StringUtil.parse_json(request_params[:rest_args].strip, symbolize: true)
       end
+    end
+
+    def allowed_params
+      worker_positional_params + worker_keyword_params
+    end
+
+    def positional_params
+      worker_klass_inspector.required_parameters(:perform) +
+        worker_klass_inspector.optional_parameters(:perform)
+    end
+
+    def keyword_params
+      worker_klass_inspector.required_kw_parameters(:perform) +
+        worker_klass_inspector.optional_kw_parameters(:perform)
     end
 
   end

--- a/lib/sidekiq_adhoc_job/strategies/active_job.rb
+++ b/lib/sidekiq_adhoc_job/strategies/active_job.rb
@@ -11,8 +11,8 @@ module SidekiqAdhocJob
         klass_name.queue_name
       end
 
-      def perform_async(klass, *params)
-        klass.perform_later(*params)
+      def perform_async(klass, *params, **kw_params)
+        klass.perform_later(*params, **kw_params)
       end
     end
   end

--- a/lib/sidekiq_adhoc_job/strategies/default.rb
+++ b/lib/sidekiq_adhoc_job/strategies/default.rb
@@ -11,8 +11,8 @@ module SidekiqAdhocJob
         klass_name.sidekiq_options['queue']
       end
 
-      def perform_async(klass, *params)
-        klass.perform_async(*params)
+      def perform_async(klass, *params, **kw_params)
+        klass.perform_async(*params, **kw_params)
       end
     end
   end

--- a/lib/sidekiq_adhoc_job/strategies/rails_application_job.rb
+++ b/lib/sidekiq_adhoc_job/strategies/rails_application_job.rb
@@ -11,8 +11,8 @@ module SidekiqAdhocJob
         klass_name.queue_name
       end
 
-      def perform_async(klass, *params)
-        klass.perform_later(*params)
+      def perform_async(klass, *params, **kw_params)
+        klass.perform_later(*params, **kw_params)
       end
     end
   end

--- a/lib/sidekiq_adhoc_job/utils/class_inspector.rb
+++ b/lib/sidekiq_adhoc_job/utils/class_inspector.rb
@@ -35,6 +35,14 @@ module SidekiqAdhocJob
         parameters(method_name)[:opt] || []
       end
 
+      def required_kw_parameters(method_name)
+        parameters(method_name)[:keyreq] || []
+      end
+
+      def optional_kw_parameters(method_name)
+        parameters(method_name)[:key] || []
+      end
+
       def has_rest_parameter?(method_name)
         !!parameters(method_name)[:rest]
       end

--- a/lib/sidekiq_adhoc_job/web/job_presenter.rb
+++ b/lib/sidekiq_adhoc_job/web/job_presenter.rb
@@ -4,7 +4,7 @@ module SidekiqAdhocJob
     class JobPresenter
       include Sidekiq::WebHelpers
 
-      attr_reader :name, :path_name, :queue, :required_args, :optional_args, :has_rest_args
+      attr_reader :name, :path_name, :queue, :required_args, :optional_args, :required_kw_args, :optional_kw_args, :has_rest_args
 
       StringUtil ||= ::SidekiqAdhocJob::Utils::String
 
@@ -15,6 +15,8 @@ module SidekiqAdhocJob
         @queue = queue
         @required_args = args[:req] || []
         @optional_args = args[:opt] || []
+        @required_kw_args = args[:keyreq] || []
+        @optional_kw_args = args[:key] || []
         @has_rest_args = !!args[:rest]
       end
 
@@ -41,6 +43,10 @@ module SidekiqAdhocJob
         class_inspector = SidekiqAdhocJob::Utils::ClassInspector.new(klass_name)
         args = class_inspector.parameters(:perform)
         new(klass_name, path_name, queue, args)
+      end
+
+      def no_arguments?
+        required_args.empty? && optional_args.empty? && required_kw_args.empty? && optional_kw_args.empty? && !has_rest_args
       end
 
     end

--- a/lib/sidekiq_adhoc_job/web/locales/en.yml
+++ b/lib/sidekiq_adhoc_job/web/locales/en.yml
@@ -1,6 +1,8 @@
 en:
   adhoc_jobs: Adhoc Jobs
   adhoc_jobs_actions: Actions
+  adhoc_jobs_required_keyword_arguments: Required Keyword Arguments
+  adhoc_jobs_optional_keyword_arguments: Optional Keyword Arguments
   adhoc_jobs_required_arguments: Required Arguments
   adhoc_jobs_optional_arguments: Optional Arguments
   adhoc_jobs_go_back: Go Back

--- a/lib/sidekiq_adhoc_job/web/templates/jobs/index.html.erb
+++ b/lib/sidekiq_adhoc_job/web/templates/jobs/index.html.erb
@@ -8,6 +8,8 @@
         <th><%= t('adhoc_jobs_queue') %></th>
         <th><%= t('adhoc_jobs_required_arguments') %></th>
         <th><%= t('adhoc_jobs_optional_arguments') %></th>
+        <th><%= t('adhoc_jobs_required_keyword_arguments') %></th>
+        <th><%= t('adhoc_jobs_optional_keyword_arguments') %></th>
         <th><%= t('adhoc_jobs_has_rest_arguments') %></th>
         <th><%= t('adhoc_jobs_actions') %></th>
       </tr>
@@ -20,6 +22,8 @@
           <td><%= job.queue %></td>
           <td><%= job.required_args.join(', ') %></td>
           <td><%= job.optional_args.join(', ') %></td>
+          <td><%= job.required_kw_args.join(', ') %></td>
+          <td><%= job.optional_kw_args.join(', ') %></td>
           <td><%= job.has_rest_args %></td>
           <td class="text-center">
             <a class="btn btn-warn btn-xs" href="<%= root_path %>adhoc-jobs/<%= CGI.escape(job.path_name) %>">

--- a/lib/sidekiq_adhoc_job/web/templates/jobs/show.html.erb
+++ b/lib/sidekiq_adhoc_job/web/templates/jobs/show.html.erb
@@ -4,7 +4,7 @@
 
 <form method="POST" action="<%= root_path %>adhoc-jobs/<%= CGI.escape(@presented_job.path_name) %>/schedule">
   <input type="hidden" name="authenticity_token" value="<%= @csrf_token %>" />
-  <% if @presented_job.required_args.empty? && @presented_job.optional_args.empty? && !@presented_job.has_rest_args %>
+  <% if @presented_job.no_arguments? %>
     <p>No job arguments</p>
   <% else %>
     <% @presented_job.required_args.each do |arg| %>
@@ -16,6 +16,22 @@
       </div>
     <% end %>
     <% @presented_job.optional_args.each do |arg| %>
+      <div class="form-group row">
+        <label class="col-sm-2 col-form-label" for="<%= arg %>"><%= arg %>:</label>
+        <div class="col-sm-4">
+          <input class="form-control" type="text" name="<%= arg %>" id="<%= arg %>"/>
+        </div>
+      </div>
+    <% end %>
+    <% @presented_job.required_kw_args.each do |arg| %>
+      <div class="form-group row">
+        <label class="col-sm-2 col-form-label" for="<%= arg %>"><%= arg %>:</label>
+        <div class="col-sm-4">
+          <input class="form-control" type="text" name="<%= arg %>" id="<%= arg %>"/>
+        </div>
+      </div>
+    <% end %>
+    <% @presented_job.optional_kw_args.each do |arg| %>
       <div class="form-group row">
         <label class="col-sm-2 col-form-label" for="<%= arg %>"><%= arg %>:</label>
         <div class="col-sm-4">

--- a/lib/sidekiq_adhoc_job/web/templates/jobs/show.html.erb
+++ b/lib/sidekiq_adhoc_job/web/templates/jobs/show.html.erb
@@ -27,7 +27,7 @@
       <div class="form-group row">
         <label class="col-sm-2 col-form-label" for="<%= arg %>"><%= arg %>:</label>
         <div class="col-sm-4">
-          <input class="form-control" type="text" name="<%= arg %>" id="<%= arg %>"/>
+          <input class="form-control" type="text" name="<%= arg %>" id="<%= arg %>" required/>
         </div>
       </div>
     <% end %>

--- a/spec/sidekiq_adhoc_job/requests/jobs/index_spec.rb
+++ b/spec/sidekiq_adhoc_job/requests/jobs/index_spec.rb
@@ -22,6 +22,8 @@ RSpec.describe 'GET /adhoc_jobs' do
         <td>dummy</td>
         <td>id, overwrite</td>
         <td>retry_job, retries, interval, name, options</td>
+        <td>type</td>
+        <td>dryrun</td>
         <td>false</td>
         <td class="text-center">
           <a class="btn btn-warn btn-xs" href="/adhoc-jobs/sidekiq_adhoc_job_test_dummy_worker">

--- a/spec/sidekiq_adhoc_job/services/schedule_adhoc_job_spec.rb
+++ b/spec/sidekiq_adhoc_job/services/schedule_adhoc_job_spec.rb
@@ -6,13 +6,33 @@ RSpec.describe SidekiqAdhocJob::ScheduleAdhocJob do
   subject { described_class }
 
   let(:job_name) { 'sidekiq_adhoc_job_test_dummy_worker' }
-  let(:params) { { 'id' => 'a937de5f-c86a-4f49-9243-d1c3bad2488f', 'overwrite' => 'true', 'retry_job' => 'true', 'retries' => '10', 'interval' => '2.5', 'name' => 'nil', 'options' => '{ "skip_check": true }' } }
+  let(:params) do
+    {
+      'id' => 'a937de5f-c86a-4f49-9243-d1c3bad2488f',
+      'overwrite' => 'true',
+      'retry_job' => 'true',
+      'retries' => '10',
+      'interval' => '2.5',
+      'name' => 'nil',
+      'options' => '{ "skip_check": true }',
+      'type' => 'foo'
+    }
+  end
 
   describe '#call' do
+    let(:expected_params) do
+      ['a937de5f-c86a-4f49-9243-d1c3bad2488f', true, true, 10, 2.5, nil, { skip_check: true }]
+    end
+    let(:expected_kw_params) do
+      {
+        :type => 'foo'
+      }
+    end
+
     it 'schedules job to run asynchronously' do
       scheduler = subject.new(job_name, params)
 
-      expect(SidekiqAdhocJob::Test::DummyWorker).to receive(:perform_async).with('a937de5f-c86a-4f49-9243-d1c3bad2488f', true, true, 10, 2.5, nil, { skip_check: true })
+      expect(SidekiqAdhocJob::Test::DummyWorker).to receive(:perform_async).with(*expected_params, **expected_kw_params)
       scheduler.call
     end
   end

--- a/spec/sidekiq_adhoc_job/web/job_presenter_spec.rb
+++ b/spec/sidekiq_adhoc_job/web/job_presenter_spec.rb
@@ -21,6 +21,8 @@ RSpec.describe SidekiqAdhocJob::Web::JobPresenter do
         expect(job_presenter.queue).to eq 'dummy'
         expect(job_presenter.required_args).to eq %i(id overwrite)
         expect(job_presenter.optional_args).to eq %i(retry_job retries interval name options)
+        expect(job_presenter.required_kw_args).to eq %i(type)
+        expect(job_presenter.optional_kw_args).to eq %i(dryrun)
         expect(job_presenter.has_rest_args).to eq false
 
         job_presenter = subject.find('sidekiq_adhoc_job_test_namespaced_worker')
@@ -29,6 +31,8 @@ RSpec.describe SidekiqAdhocJob::Web::JobPresenter do
         expect(job_presenter.queue).to eq 'dummy'
         expect(job_presenter.required_args).to eq %i()
         expect(job_presenter.optional_args).to eq %i()
+        expect(job_presenter.required_kw_args).to eq %i()
+        expect(job_presenter.optional_kw_args).to eq %i()
         expect(job_presenter.has_rest_args).to eq false
 
         job_presenter = subject.find('sidekiq_adhoc_job_test_worker_nested_namespaced_worker')
@@ -37,6 +41,8 @@ RSpec.describe SidekiqAdhocJob::Web::JobPresenter do
         expect(job_presenter.queue).to eq 'dummy'
         expect(job_presenter.required_args).to eq %i()
         expect(job_presenter.optional_args).to eq %i()
+        expect(job_presenter.required_kw_args).to eq %i()
+        expect(job_presenter.optional_kw_args).to eq %i()
         expect(job_presenter.has_rest_args).to eq false
 
         job_presenter = subject.find('sidekiq_adhoc_job_test_dummy_rest_args_worker')
@@ -45,6 +51,8 @@ RSpec.describe SidekiqAdhocJob::Web::JobPresenter do
         expect(job_presenter.queue).to eq 'dummy'
         expect(job_presenter.required_args).to eq %i(id)
         expect(job_presenter.optional_args).to eq %i()
+        expect(job_presenter.required_kw_args).to eq %i()
+        expect(job_presenter.optional_kw_args).to eq %i()
         expect(job_presenter.has_rest_args).to eq true
 
         job_presenter = subject.find('sidekiq_adhoc_job_test_prepended_worker')
@@ -53,6 +61,8 @@ RSpec.describe SidekiqAdhocJob::Web::JobPresenter do
         expect(job_presenter.queue).to eq 'dummy'
         expect(job_presenter.required_args).to eq %i(id overwrite)
         expect(job_presenter.optional_args).to eq %i(retry_job retries interval)
+        expect(job_presenter.required_kw_args).to eq %i()
+        expect(job_presenter.optional_kw_args).to eq %i()
         expect(job_presenter.has_rest_args).to eq false
 
         job_presenter = subject.find('sidekiq_adhoc_job_test_nested_prepended_worker')
@@ -61,6 +71,8 @@ RSpec.describe SidekiqAdhocJob::Web::JobPresenter do
         expect(job_presenter.queue).to eq 'dummy'
         expect(job_presenter.required_args).to eq %i(id overwrite)
         expect(job_presenter.optional_args).to eq %i(retry_job retries interval)
+        expect(job_presenter.required_kw_args).to eq %i()
+        expect(job_presenter.optional_kw_args).to eq %i()
         expect(job_presenter.has_rest_args).to eq false
 
         job_presenter = subject.find('sidekiq_adhoc_job_test_sample_csv_worker')
@@ -69,6 +81,8 @@ RSpec.describe SidekiqAdhocJob::Web::JobPresenter do
         expect(job_presenter.queue).to eq 'dummy'
         expect(job_presenter.required_args).to eq %i()
         expect(job_presenter.optional_args).to eq %i()
+        expect(job_presenter.required_kw_args).to eq %i()
+        expect(job_presenter.optional_kw_args).to eq %i()
         expect(job_presenter.has_rest_args).to eq false
 
         job_presenter = subject.find('sidekiq_adhoc_job_test_non_explicit')
@@ -77,6 +91,8 @@ RSpec.describe SidekiqAdhocJob::Web::JobPresenter do
         expect(job_presenter.queue).to eq 'dummy'
         expect(job_presenter.required_args).to eq %i()
         expect(job_presenter.optional_args).to eq %i()
+        expect(job_presenter.required_kw_args).to eq %i()
+        expect(job_presenter.optional_kw_args).to eq %i()
         expect(job_presenter.has_rest_args).to eq false
       end
     end

--- a/spec/support/fixtures/workers/dummy_worker.rb
+++ b/spec/support/fixtures/workers/dummy_worker.rb
@@ -7,7 +7,7 @@ module SidekiqAdhocJob
 
       sidekiq_options queue: 'dummy'
 
-      def perform(id, overwrite, retry_job = true, retries = 5, interval = 1.5, name = nil, options = {})
+      def perform(id, overwrite, retry_job = true, retries = 5, interval = 1.5, name = nil, options = {}, type:, dryrun: false)
       end
 
     end


### PR DESCRIPTION
# Background
This PR adds keyword argument support to the gem
```
class CreateEventJob < ApplicationJob
  queue_as :default

  def perform(event_type:, event_payload:)
    @event_type = event_type
    @event_payload = event_payload
    ...
```
Previously, a worker/job like this would not have it's keyword args registered by the gem. Instead, the gem would incorrectly detect it as REST params.

This PR adds support for optional and required keyword args, as shown below:
![image](https://user-images.githubusercontent.com/19161092/125250393-c4824200-e328-11eb-893e-e6d41c898380.png)
![image](https://user-images.githubusercontent.com/19161092/125250726-2b9ff680-e329-11eb-82e0-e64bd5313da2.png)
