### PR TITLE
Allow user to input any arguments from Web UI

### DIFF
--- a/lib/sidekiq_adhoc_job.rb
+++ b/lib/sidekiq_adhoc_job.rb
@@ -41,12 +41,13 @@ module SidekiqAdhocJob
   end
 
   class Configuration
-    attr_accessor :load_paths, :module_names, :strategy_name
+    attr_accessor :load_paths, :module_names, :strategy_name, :allow_override_params
 
     def initialize
       @load_paths = []
       @module_names = []
       @strategy_name = :default
+      @allow_override_params = false
     end
 
     def module_names

--- a/lib/sidekiq_adhoc_job/web/templates/jobs/show.html.erb
+++ b/lib/sidekiq_adhoc_job/web/templates/jobs/show.html.erb
@@ -2,37 +2,39 @@
 
 <h4><%= SidekiqAdhocJob::Utils::String.classify(@presented_job.path_name) %></h4>
 
-<p>Let me override all the arguments, I know what I'm doing.</p>
+<% if SidekiqAdhocJob.config.allow_override_params %>
+  <p>Let me override all the arguments, I know what I'm doing.</p>
 
-<form method="POST" action="<%= root_path %>adhoc-jobs/<%= CGI.escape(@presented_job.path_name) %>/schedule">
-  <input type="hidden" name="authenticity_token" value="<%= @csrf_token %>" />
-  <div class="form-group row">
-    <label class="col-sm-2 col-form-label" for="override_args">Let me override all the arguments, I know what I'm doing.</label><br>
-    <div class="col-sm-4">
-      <input class="form-control" type="text" name="override_args" id="override_args" placeholder="Type the exact phrase 'let_me_override'" />
+  <form method="POST" action="<%= root_path %>adhoc-jobs/<%= CGI.escape(@presented_job.path_name) %>/schedule">
+    <input type="hidden" name="authenticity_token" value="<%= @csrf_token %>" />
+    <div class="form-group row">
+      <label class="col-sm-2 col-form-label" for="override_args">Let me override all the arguments, I know what I'm doing.</label><br>
+      <div class="col-sm-4">
+        <input class="form-control" type="text" name="override_args" id="override_args" placeholder="Type the exact phrase: let_me_override" />
+      </div>
     </div>
-  </div>
-  <div class="form-group row">
-    <label class="col-sm-2 col-form-label" for="posargs">Positional Args (please provide a json string representing the array of arguments):</label>
-    <div class="col-sm-4">
-      <input class="form-control" type="text" name="positional_args" id="posargs"/>
+    <div class="form-group row">
+      <label class="col-sm-2 col-form-label" for="posargs">Positional Args (please provide a json string representing the array of arguments):</label>
+      <div class="col-sm-4">
+        <input class="form-control" type="text" name="positional_args" id="posargs"/>
+      </div>
     </div>
-  </div>
-  <div class="form-group row">
-    <label class="col-sm-2 col-form-label" for="kwargs">Keyword Args (please provide a json string representing the hash of arguments):</label>
-    <div class="col-sm-4">
-      <input class="form-control" type="text" name="keyword_args" id="kwargs"/>
+    <div class="form-group row">
+      <label class="col-sm-2 col-form-label" for="kwargs">Keyword Args (please provide a json string representing the hash of arguments):</label>
+      <div class="col-sm-4">
+        <input class="form-control" type="text" name="keyword_args" id="kwargs"/>
+      </div>
     </div>
-  </div>
-  <div class="form-group row">
-    <div class="col-sm-4">
-      <button type="submit" class="btn btn-danger"><%= t('adhoc_jobs_run_job') %></button>
-      <a class="btn" href="<%= root_path %>adhoc-jobs"><%= t('adhoc_jobs_go_back') %></a>
+    <div class="form-group row">
+      <div class="col-sm-4">
+        <button type="submit" class="btn btn-danger"><%= t('adhoc_jobs_run_job') %></button>
+        <a class="btn" href="<%= root_path %>adhoc-jobs"><%= t('adhoc_jobs_go_back') %></a>
+      </div>
     </div>
-  </div>
-</form>
+  </form>
 
-<hr>
+  <hr>
+<% end %>
 
 <form method="POST" action="<%= root_path %>adhoc-jobs/<%= CGI.escape(@presented_job.path_name) %>/schedule">
   <input type="hidden" name="authenticity_token" value="<%= @csrf_token %>" />

--- a/lib/sidekiq_adhoc_job/web/templates/jobs/show.html.erb
+++ b/lib/sidekiq_adhoc_job/web/templates/jobs/show.html.erb
@@ -2,6 +2,38 @@
 
 <h4><%= SidekiqAdhocJob::Utils::String.classify(@presented_job.path_name) %></h4>
 
+<p>Let me override all the arguments, I know what I'm doing.</p>
+
+<form method="POST" action="<%= root_path %>adhoc-jobs/<%= CGI.escape(@presented_job.path_name) %>/schedule">
+  <input type="hidden" name="authenticity_token" value="<%= @csrf_token %>" />
+  <div class="form-group row">
+    <label class="col-sm-2 col-form-label" for="override_args">Let me override all the arguments, I know what I'm doing.</label><br>
+    <div class="col-sm-4">
+      <input class="form-control" type="text" name="override_args" id="override_args" placeholder="Type the exact phrase 'let_me_override'" />
+    </div>
+  </div>
+  <div class="form-group row">
+    <label class="col-sm-2 col-form-label" for="posargs">Positional Args (please provide a json string representing the array of arguments):</label>
+    <div class="col-sm-4">
+      <input class="form-control" type="text" name="positional_args" id="posargs"/>
+    </div>
+  </div>
+  <div class="form-group row">
+    <label class="col-sm-2 col-form-label" for="kwargs">Keyword Args (please provide a json string representing the hash of arguments):</label>
+    <div class="col-sm-4">
+      <input class="form-control" type="text" name="keyword_args" id="kwargs"/>
+    </div>
+  </div>
+  <div class="form-group row">
+    <div class="col-sm-4">
+      <button type="submit" class="btn btn-danger"><%= t('adhoc_jobs_run_job') %></button>
+      <a class="btn" href="<%= root_path %>adhoc-jobs"><%= t('adhoc_jobs_go_back') %></a>
+    </div>
+  </div>
+</form>
+
+<hr>
+
 <form method="POST" action="<%= root_path %>adhoc-jobs/<%= CGI.escape(@presented_job.path_name) %>/schedule">
   <input type="hidden" name="authenticity_token" value="<%= @csrf_token %>" />
   <% if @presented_job.no_arguments? %>

--- a/spec/sidekiq_adhoc_job/services/schedule_adhoc_job_spec.rb
+++ b/spec/sidekiq_adhoc_job/services/schedule_adhoc_job_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe SidekiqAdhocJob::ScheduleAdhocJob do
     end
     let(:expected_kw_params) do
       {
-        :type => 'foo'
+        type: 'foo'
       }
     end
 
@@ -34,6 +34,53 @@ RSpec.describe SidekiqAdhocJob::ScheduleAdhocJob do
 
       expect(SidekiqAdhocJob::Test::DummyWorker).to receive(:perform_async).with(*expected_params, **expected_kw_params)
       scheduler.call
+    end
+
+    context 'with override' do
+      let(:params) do
+        {
+          override_args: 'let_me_override',
+          positional_args: positional_args.to_json,
+          keyword_args: keyword_args.to_json
+        }
+      end
+
+      let(:positional_args) do
+        ['a937de5f-c86a-4f49-9243-d1c3bad2488f', true, true, 10, 2.5, nil, { skip_check: true }]
+      end
+
+      let(:keyword_args) do
+        {
+          type: 'foo'
+        }
+      end
+
+      it 'schedules job to run asynchronously' do
+        scheduler = subject.new(job_name, params)
+
+        expect(SidekiqAdhocJob::Test::DummyWorker).to receive(:perform_async).with(*expected_params, **expected_kw_params)
+        scheduler.call
+      end
+    end
+
+    context 'with override but empty params' do
+      let(:params) do
+        {
+          override_args: 'let_me_override',
+          positional_args: '',
+          keyword_args: ''
+        }
+      end
+
+      let(:expected_params) { [] }
+      let(:expected_kw_params) { {} }
+
+      it 'schedules job to run asynchronously' do
+        scheduler = subject.new(job_name, params)
+
+        expect(SidekiqAdhocJob::Test::DummyWorker).to receive(:perform_async).with(*expected_params, **expected_kw_params)
+        scheduler.call
+      end
     end
   end
 

--- a/spec/sidekiq_adhoc_job/utils/class_inspector_spec.rb
+++ b/spec/sidekiq_adhoc_job/utils/class_inspector_spec.rb
@@ -9,7 +9,9 @@ RSpec.describe SidekiqAdhocJob::Utils::ClassInspector do
     it do
       expect(inspector.parameters(:perform)).to eq({
         opt: [:retry_job, :retries, :interval, :name, :options],
-        req: [:id, :overwrite]
+        req: [:id, :overwrite],
+        keyreq: [:type],
+        key: [:dryrun]
       })
     end
   end


### PR DESCRIPTION
While it is good to provide some structure to the job parameters input to reduce the chance of mistakes, sometimes we just need that sudo feature that overrides whatever the gem tells us we should do.

This PR adds a simple form in the View Job UI that lets the user input any positional + keyword arguments instead of using the structured form.

![Screenshot 2021-07-16 at 3 32 51 PM](https://user-images.githubusercontent.com/1378570/125909881-acf7aa9d-a3d5-40be-8859-93feb9743bb2.png)

