### PR TITLE
Feature/add confirmation

### DIFF
--- a/lib/sidekiq_adhoc_job.rb
+++ b/lib/sidekiq_adhoc_job.rb
@@ -41,12 +41,14 @@ module SidekiqAdhocJob
   end
 
   class Configuration
-    attr_accessor :load_paths, :module_names, :strategy_name, :require_confirm_module_names
+    attr_accessor :load_paths,
+                  :module_names,
+                  :strategy_name,
+                  :require_confirm_worker_names
 
     def initialize
       @load_paths = []
       @module_names = []
-      @require_confirm = nil
       @strategy_name = :default
     end
 
@@ -55,7 +57,11 @@ module SidekiqAdhocJob
     end
 
     def require_confirm
-      @require_confirm ||= Array(@require_confirm_module_names).map(&:to_s)
+      @require_confirm ||= Array(@require_confirm_worker_names).map(&:to_s)
+    end
+
+    def require_confirmation?(worker_name)
+      require_confirm.include?(worker_name)
     end
 
     def strategy

--- a/lib/sidekiq_adhoc_job.rb
+++ b/lib/sidekiq_adhoc_job.rb
@@ -41,16 +41,21 @@ module SidekiqAdhocJob
   end
 
   class Configuration
-    attr_accessor :load_paths, :module_names, :strategy_name
+    attr_accessor :load_paths, :module_names, :strategy_name, :require_confirm_module_names
 
     def initialize
       @load_paths = []
       @module_names = []
+      @require_confirm = nil
       @strategy_name = :default
     end
 
     def module_names
       Array(@module_names).map(&:to_s)
+    end
+
+    def require_confirm
+      @require_confirm ||= Array(@require_confirm_module_names).map(&:to_s)
     end
 
     def strategy

--- a/lib/sidekiq_adhoc_job/utils/class_inspector.rb
+++ b/lib/sidekiq_adhoc_job/utils/class_inspector.rb
@@ -27,6 +27,10 @@ module SidekiqAdhocJob
         params
       end
 
+      def require_confirm?
+        klass_obj.methods.include?(:confirm) && klass_obj.confirm
+      end
+
       def required_parameters(method_name)
         parameters(method_name)[:req] || []
       end

--- a/lib/sidekiq_adhoc_job/utils/class_inspector.rb
+++ b/lib/sidekiq_adhoc_job/utils/class_inspector.rb
@@ -27,10 +27,6 @@ module SidekiqAdhocJob
         params
       end
 
-      def require_confirm?
-        klass_obj.methods.include?(:confirm) && klass_obj.confirm
-      end
-
       def required_parameters(method_name)
         parameters(method_name)[:req] || []
       end

--- a/lib/sidekiq_adhoc_job/web/job_presenter.rb
+++ b/lib/sidekiq_adhoc_job/web/job_presenter.rb
@@ -4,12 +4,20 @@ module SidekiqAdhocJob
     class JobPresenter
       include Sidekiq::WebHelpers
 
-      attr_reader :name, :path_name, :queue, :required_args, :optional_args, :required_kw_args, :optional_kw_args, :has_rest_args, :require_confirm
+      attr_reader :name,
+                  :path_name,
+                  :queue,
+                  :required_args,
+                  :optional_args,
+                  :required_kw_args,
+                  :optional_kw_args,
+                  :has_rest_args,
+                  :require_confirm
 
       StringUtil ||= ::SidekiqAdhocJob::Utils::String
 
       # args: { req: [], opt: [] }
-      def initialize(name, path_name, queue, args, confirm)
+      def initialize(name, path_name, queue, args, require_confirm)
         @name = name
         @path_name = path_name
         @queue = queue
@@ -18,7 +26,7 @@ module SidekiqAdhocJob
         @required_kw_args = args[:keyreq] || []
         @optional_kw_args = args[:key] || []
         @has_rest_args = !!args[:rest]
-        @require_confirm = confirm
+        @require_confirm = require_confirm
       end
 
       # Builds the presenter instances for the schedule hash
@@ -43,8 +51,8 @@ module SidekiqAdhocJob
         queue = SidekiqAdhocJob.config.strategy.get_queue_name(klass_name)
         class_inspector = SidekiqAdhocJob::Utils::ClassInspector.new(klass_name)
         args = class_inspector.parameters(:perform)
-        confirm = class_inspector.require_confirm?
-        new(klass_name, path_name, queue, args, confirm)
+        require_confirm = SidekiqAdhocJob.config.require_confirm.include?(klass_name.to_s)
+        new(klass_name, path_name, queue, args, require_confirm)
       end
 
       def no_arguments?

--- a/lib/sidekiq_adhoc_job/web/job_presenter.rb
+++ b/lib/sidekiq_adhoc_job/web/job_presenter.rb
@@ -4,12 +4,12 @@ module SidekiqAdhocJob
     class JobPresenter
       include Sidekiq::WebHelpers
 
-      attr_reader :name, :path_name, :queue, :required_args, :optional_args, :required_kw_args, :optional_kw_args, :has_rest_args
+      attr_reader :name, :path_name, :queue, :required_args, :optional_args, :required_kw_args, :optional_kw_args, :has_rest_args, :require_confirm
 
       StringUtil ||= ::SidekiqAdhocJob::Utils::String
 
       # args: { req: [], opt: [] }
-      def initialize(name, path_name, queue, args)
+      def initialize(name, path_name, queue, args, confirm)
         @name = name
         @path_name = path_name
         @queue = queue
@@ -18,6 +18,7 @@ module SidekiqAdhocJob
         @required_kw_args = args[:keyreq] || []
         @optional_kw_args = args[:key] || []
         @has_rest_args = !!args[:rest]
+        @require_confirm = confirm
       end
 
       # Builds the presenter instances for the schedule hash
@@ -42,7 +43,8 @@ module SidekiqAdhocJob
         queue = SidekiqAdhocJob.config.strategy.get_queue_name(klass_name)
         class_inspector = SidekiqAdhocJob::Utils::ClassInspector.new(klass_name)
         args = class_inspector.parameters(:perform)
-        new(klass_name, path_name, queue, args)
+        confirm = class_inspector.require_confirm?
+        new(klass_name, path_name, queue, args, confirm)
       end
 
       def no_arguments?

--- a/lib/sidekiq_adhoc_job/web/job_presenter.rb
+++ b/lib/sidekiq_adhoc_job/web/job_presenter.rb
@@ -51,7 +51,7 @@ module SidekiqAdhocJob
         queue = SidekiqAdhocJob.config.strategy.get_queue_name(klass_name)
         class_inspector = SidekiqAdhocJob::Utils::ClassInspector.new(klass_name)
         args = class_inspector.parameters(:perform)
-        require_confirm = SidekiqAdhocJob.config.require_confirm.include?(klass_name.to_s)
+        require_confirm = SidekiqAdhocJob.config.require_confirmation?(klass_name.to_s)
         new(klass_name, path_name, queue, args, require_confirm)
       end
 

--- a/lib/sidekiq_adhoc_job/web/locales/en.yml
+++ b/lib/sidekiq_adhoc_job/web/locales/en.yml
@@ -7,6 +7,7 @@ en:
   adhoc_jobs_optional_arguments: Optional Arguments
   adhoc_jobs_go_back: Go Back
   adhoc_jobs_has_rest_arguments: Has Rest Arguments
+  adhoc_jobs_confirm_required: Confirm Required
   adhoc_jobs_name: Job Name
   adhoc_jobs_queue: Job Queue
   adhoc_jobs_run_job: Run Job

--- a/lib/sidekiq_adhoc_job/web/templates/jobs/index.html.erb
+++ b/lib/sidekiq_adhoc_job/web/templates/jobs/index.html.erb
@@ -11,6 +11,7 @@
         <th><%= t('adhoc_jobs_required_keyword_arguments') %></th>
         <th><%= t('adhoc_jobs_optional_keyword_arguments') %></th>
         <th><%= t('adhoc_jobs_has_rest_arguments') %></th>
+        <th><%= t('adhoc_jobs_confirm_required') %></th>
         <th><%= t('adhoc_jobs_actions') %></th>
       </tr>
     </thead>
@@ -25,6 +26,7 @@
           <td><%= job.required_kw_args.join(', ') %></td>
           <td><%= job.optional_kw_args.join(', ') %></td>
           <td><%= job.has_rest_args %></td>
+          <td><%= job.require_confirm %></td>
           <td class="text-center">
             <a class="btn btn-warn btn-xs" href="<%= root_path %>adhoc-jobs/<%= CGI.escape(job.path_name) %>">
               <%= t('adhoc_jobs_view_job') %>

--- a/lib/sidekiq_adhoc_job/web/templates/jobs/show.html.erb
+++ b/lib/sidekiq_adhoc_job/web/templates/jobs/show.html.erb
@@ -50,7 +50,7 @@
   <% end %>
   <div class="form-group row">
     <div class="col-sm-4">
-      <button type="submit" class="btn btn-danger" ><%= t('adhoc_jobs_run_job') %></button>
+      <button type="submit" class="btn btn-danger"><%= t('adhoc_jobs_run_job') %></button>
       <a class="btn" href="<%= root_path %>adhoc-jobs"><%= t('adhoc_jobs_go_back') %></a>
     </div>
   </div>

--- a/lib/sidekiq_adhoc_job/web/templates/jobs/show.html.erb
+++ b/lib/sidekiq_adhoc_job/web/templates/jobs/show.html.erb
@@ -2,7 +2,7 @@
 
 <h4><%= SidekiqAdhocJob::Utils::String.classify(@presented_job.path_name) %></h4>
 
-<form method="POST" action="<%= root_path %>adhoc-jobs/<%= CGI.escape(@presented_job.path_name) %>/schedule" <%= 'id="confirm"' if @presented_job.require_confirm %> >
+<form method="POST" action="<%= root_path %>adhoc-jobs/<%= CGI.escape(@presented_job.path_name) %>/schedule" id="adhoc-jobs-submit-form">
   <input type="hidden" name="authenticity_token" value="<%= @csrf_token %>" />
   <% if @presented_job.no_arguments? %>
     <p>No job arguments</p>
@@ -56,9 +56,11 @@
   </div>
 </form>
 
-<script>
-  document.getElementById('confirm').addEventListener('submit', (event) => {
-    if (!confirm('Are you sure?'))
-      event.preventDefault();
-  })
-</script>
+<% if @presented_job.require_confirm %>
+  <script>
+    document.getElementById('adhoc-jobs-submit-form').addEventListener('submit', (event) => {
+      if (!confirm('Are you sure?'))
+        event.preventDefault();
+    })
+  </script>
+<% end %>

--- a/lib/sidekiq_adhoc_job/web/templates/jobs/show.html.erb
+++ b/lib/sidekiq_adhoc_job/web/templates/jobs/show.html.erb
@@ -2,7 +2,7 @@
 
 <h4><%= SidekiqAdhocJob::Utils::String.classify(@presented_job.path_name) %></h4>
 
-<form method="POST" action="<%= root_path %>adhoc-jobs/<%= CGI.escape(@presented_job.path_name) %>/schedule">
+<form method="POST" action="<%= root_path %>adhoc-jobs/<%= CGI.escape(@presented_job.path_name) %>/schedule" <%= 'id="confirm"' if @presented_job.require_confirm %> >
   <input type="hidden" name="authenticity_token" value="<%= @csrf_token %>" />
   <% if @presented_job.no_arguments? %>
     <p>No job arguments</p>
@@ -50,8 +50,15 @@
   <% end %>
   <div class="form-group row">
     <div class="col-sm-4">
-      <button type="submit" class="btn btn-danger"><%= t('adhoc_jobs_run_job') %></button>
+      <button type="submit" class="btn btn-danger" ><%= t('adhoc_jobs_run_job') %></button>
       <a class="btn" href="<%= root_path %>adhoc-jobs"><%= t('adhoc_jobs_go_back') %></a>
     </div>
   </div>
 </form>
+
+<script>
+  document.getElementById('confirm').addEventListener('submit', (event) => {
+    if (!confirm('Are you sure?'))
+      event.preventDefault();
+  })
+</script>

--- a/spec/sidekiq_adhoc_job/requests/jobs/index_spec.rb
+++ b/spec/sidekiq_adhoc_job/requests/jobs/index_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe 'GET /adhoc_jobs' do
         <td>type</td>
         <td>dryrun</td>
         <td>false</td>
+        <td>false</td>
         <td class="text-center">
           <a class="btn btn-warn btn-xs" href="/adhoc-jobs/sidekiq_adhoc_job_test_dummy_worker">
             View Job

--- a/spec/sidekiq_adhoc_job/utils/class_inspector_spec.rb
+++ b/spec/sidekiq_adhoc_job/utils/class_inspector_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe SidekiqAdhocJob::Utils::ClassInspector do
   describe "#parameters" do
     it do
       expect(inspector.parameters(:perform)).to eq({
-        :key => [:dryrun],
-        :keyreq => [:type],
+        key: [:dryrun],
+        keyreq: [:type],
         opt: [:retry_job, :retries, :interval, :name, :options],
         req: [:id, :overwrite]
       })

--- a/spec/sidekiq_adhoc_job/utils/class_inspector_spec.rb
+++ b/spec/sidekiq_adhoc_job/utils/class_inspector_spec.rb
@@ -8,6 +8,8 @@ RSpec.describe SidekiqAdhocJob::Utils::ClassInspector do
   describe "#parameters" do
     it do
       expect(inspector.parameters(:perform)).to eq({
+        :key => [:dryrun],
+        :keyreq => [:type],
         opt: [:retry_job, :retries, :interval, :name, :options],
         req: [:id, :overwrite]
       })

--- a/spec/sidekiq_adhoc_job/web/job_presenter_spec.rb
+++ b/spec/sidekiq_adhoc_job/web/job_presenter_spec.rb
@@ -57,6 +57,7 @@ RSpec.describe SidekiqAdhocJob::Web::JobPresenter do
         expect(job_presenter.required_kw_args).to eq %i()
         expect(job_presenter.optional_kw_args).to eq %i()
         expect(job_presenter.has_rest_args).to eq true
+        expect(job_presenter.require_confirm).to eq false
 
         job_presenter = subject.find('sidekiq_adhoc_job_test_prepended_worker')
         expect(job_presenter.name).to eq SidekiqAdhocJob::Test::PrependedWorker

--- a/spec/sidekiq_adhoc_job/web/job_presenter_spec.rb
+++ b/spec/sidekiq_adhoc_job/web/job_presenter_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe SidekiqAdhocJob::Web::JobPresenter do
         expect(job_presenter.required_kw_args).to eq %i(type)
         expect(job_presenter.optional_kw_args).to eq %i(dryrun)
         expect(job_presenter.has_rest_args).to eq false
+        expect(job_presenter.require_confirm).to eq false
 
         job_presenter = subject.find('sidekiq_adhoc_job_test_namespaced_worker')
         expect(job_presenter.name).to eq SidekiqAdhocJob::Test::NamespacedWorker
@@ -34,6 +35,7 @@ RSpec.describe SidekiqAdhocJob::Web::JobPresenter do
         expect(job_presenter.required_kw_args).to eq %i()
         expect(job_presenter.optional_kw_args).to eq %i()
         expect(job_presenter.has_rest_args).to eq false
+        expect(job_presenter.require_confirm).to eq true
 
         job_presenter = subject.find('sidekiq_adhoc_job_test_worker_nested_namespaced_worker')
         expect(job_presenter.name).to eq SidekiqAdhocJob::Test::Worker::NestedNamespacedWorker
@@ -44,6 +46,7 @@ RSpec.describe SidekiqAdhocJob::Web::JobPresenter do
         expect(job_presenter.required_kw_args).to eq %i()
         expect(job_presenter.optional_kw_args).to eq %i()
         expect(job_presenter.has_rest_args).to eq false
+        expect(job_presenter.require_confirm).to eq false
 
         job_presenter = subject.find('sidekiq_adhoc_job_test_dummy_rest_args_worker')
         expect(job_presenter.name).to eq SidekiqAdhocJob::Test::DummyRestArgsWorker
@@ -64,6 +67,7 @@ RSpec.describe SidekiqAdhocJob::Web::JobPresenter do
         expect(job_presenter.required_kw_args).to eq %i()
         expect(job_presenter.optional_kw_args).to eq %i()
         expect(job_presenter.has_rest_args).to eq false
+        expect(job_presenter.require_confirm).to eq false
 
         job_presenter = subject.find('sidekiq_adhoc_job_test_nested_prepended_worker')
         expect(job_presenter.name).to eq SidekiqAdhocJob::Test::NestedPrependedWorker
@@ -74,6 +78,7 @@ RSpec.describe SidekiqAdhocJob::Web::JobPresenter do
         expect(job_presenter.required_kw_args).to eq %i()
         expect(job_presenter.optional_kw_args).to eq %i()
         expect(job_presenter.has_rest_args).to eq false
+        expect(job_presenter.require_confirm).to eq false
 
         job_presenter = subject.find('sidekiq_adhoc_job_test_sample_csv_worker')
         expect(job_presenter.name).to eq SidekiqAdhocJob::Test::SampleCSVWorker
@@ -84,6 +89,7 @@ RSpec.describe SidekiqAdhocJob::Web::JobPresenter do
         expect(job_presenter.required_kw_args).to eq %i()
         expect(job_presenter.optional_kw_args).to eq %i()
         expect(job_presenter.has_rest_args).to eq false
+        expect(job_presenter.require_confirm).to eq true
 
         job_presenter = subject.find('sidekiq_adhoc_job_test_non_explicit')
         expect(job_presenter.name).to eq SidekiqAdhocJob::Test::NonExplicit
@@ -94,6 +100,7 @@ RSpec.describe SidekiqAdhocJob::Web::JobPresenter do
         expect(job_presenter.required_kw_args).to eq %i()
         expect(job_presenter.optional_kw_args).to eq %i()
         expect(job_presenter.has_rest_args).to eq false
+        expect(job_presenter.require_confirm).to eq false
       end
     end
 

--- a/spec/support/sidekiq_adhoc_job_setup.rb
+++ b/spec/support/sidekiq_adhoc_job_setup.rb
@@ -4,7 +4,7 @@ RSpec.shared_context 'SidekiqAdhocJob setup' do
   before do
     SidekiqAdhocJob.configure do |config|
       config.module_names = [:'SidekiqAdhocJob::Test', :'SidekiqAdhocJob::Test::Worker']
-      config.require_confirm_module_names = 
+      config.require_confirm_worker_names = 
         %w[
           SidekiqAdhocJob::Test::NamespacedWorker
           SidekiqAdhocJob::Test::SampleCSVWorker

--- a/spec/support/sidekiq_adhoc_job_setup.rb
+++ b/spec/support/sidekiq_adhoc_job_setup.rb
@@ -4,6 +4,11 @@ RSpec.shared_context 'SidekiqAdhocJob setup' do
   before do
     SidekiqAdhocJob.configure do |config|
       config.module_names = [:'SidekiqAdhocJob::Test', :'SidekiqAdhocJob::Test::Worker']
+      config.require_confirm_module_names = 
+        %w[
+          SidekiqAdhocJob::Test::NamespacedWorker
+          SidekiqAdhocJob::Test::SampleCSVWorker
+        ]
     end
     SidekiqAdhocJob.init
   end


### PR DESCRIPTION
# Background

There can be some workers that require further confirmation to avoid unnecessary incidents.

# What's this change

To make a worker to be considered `confirm_required`, define a method `confirm` in the worker class and returns `true`. An additional column in adhoc jobs index page will specify which worker requires confirmation.

<img width="1190" alt="image" src="https://user-images.githubusercontent.com/99305093/156971605-0277fbcd-248a-421c-98c1-006e14628d59.png">

For any `confirm_required` worker, a confirmation dialogue will be popped up when clicking `Run job` button.
 
<img width="833" alt="image" src="https://user-images.githubusercontent.com/99305093/156969654-3141b300-2c6e-44c4-ac0e-85bd1f62aa9f.png">
