### PR TITLE
Add prompted confirmation

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Options:
   - `rails_application_job`: check for all classes that extend `ApplicationJob`
 - `load_paths` (optional - default `[]`): takes in a list of file paths that the gem should load when initializing, in order to include the necessary classes in the app `ObjectSpace`
 - `require_confirm_worker_names` (optional - default `[]`): takes in a list of fully namespaced worker class names that the web UI will request for confirmation before running the job
+- `require_confirm_prompt_message` (optional - default `confirm`): takes a string that is used for challenge keyword before running jobs included in `require_confirm_worker_names`. This value must be a string, otherwise, an error with message `'require_confirm_prompt_message must be string'` will be raised
 
 ### Keyword Arguments Support (>= v2.1.0)
 
@@ -75,4 +76,8 @@ Note: There is no UI validation for the input, as the class inspector will not b
 
 ### Require Confirmation
 
-If the `require_confirm_worker_names` option is configured with the worker class name of the job you want to run, it will prompt for confirmation. You will be required to type a specific keyword for the job to run, otherwise, it will not run. This keyword is set to `confirm` by default and can be customized using `require_confirm_prompt_message` option. This helps to prevent accidentally running a critical job when not meant to be.
+If you're using sidekiq adhoc jobs in Production, you may want to consider using this configuration as an extra protection against erroneously running a sidekiq job. Once turned on, the user will be required to enter a challenge keyword in a prompt before the job can be run through the admin UI.
+
+To use this feature, add the worker class name of the jobs you would like to add the confirmation for into the `require_confirm_worker_names` option.
+
+The challenge keyword is set to be `confirm` as default, if you would like to configure the challenge keyword, you can use the `require_confirm_prompt_message` option.

--- a/README.md
+++ b/README.md
@@ -75,4 +75,4 @@ Note: There is no UI validation for the input, as the class inspector will not b
 
 ### Require Confirmation
 
-If the `require_confirm_worker_names` option is configured with the worker class name of the job you want to run, it will prompt for confirmation. By clicking `OK`, the job will be scheduled to run; otherwise, it will not run. This helps to prevent accidentally running a critical job when not meant to be.
+If the `require_confirm_worker_names` option is configured with the worker class name of the job you want to run, it will prompt for confirmation. You will be required to type a specific keyword for the job to run, otherwise, it will not run. This keyword is set to `confirm` by default and can be customized using `require_confirm_prompt_message` option. This helps to prevent accidentally running a critical job when not meant to be.

--- a/lib/sidekiq_adhoc_job.rb
+++ b/lib/sidekiq_adhoc_job.rb
@@ -44,7 +44,9 @@ module SidekiqAdhocJob
     attr_accessor :load_paths,
                   :module_names,
                   :strategy_name,
-                  :require_confirm_worker_names
+                  :require_confirm_worker_names,
+                  :require_confirm_prompt_message,
+                  :require_confirm_prompt_worker_names
 
     def initialize
       @load_paths = []
@@ -60,8 +62,16 @@ module SidekiqAdhocJob
       @require_confirm ||= Array(@require_confirm_worker_names).map(&:to_s)
     end
 
-    def require_confirmation?(worker_name)
-      require_confirm.include?(worker_name)
+    def require_confirm_prompt
+      @require_confirm_prompt ||= Array(@require_confirm_prompt_worker_names).map(&:to_s)
+    end
+
+    def require_confirmation_type(worker_name)
+      if require_confirm.include?(worker_name)
+        'confirm'
+      elsif require_confirm_prompt.include?(worker_name)
+        'prompt'
+      end
     end
 
     def strategy

--- a/lib/sidekiq_adhoc_job.rb
+++ b/lib/sidekiq_adhoc_job.rb
@@ -45,8 +45,7 @@ module SidekiqAdhocJob
                   :module_names,
                   :strategy_name,
                   :require_confirm_worker_names,
-                  :require_confirm_prompt_message,
-                  :require_confirm_prompt_worker_names
+                  :require_confirm_prompt_message
 
     def initialize
       @load_paths = []
@@ -62,16 +61,8 @@ module SidekiqAdhocJob
       @require_confirm ||= Array(@require_confirm_worker_names).map(&:to_s)
     end
 
-    def require_confirm_prompt
-      @require_confirm_prompt ||= Array(@require_confirm_prompt_worker_names).map(&:to_s)
-    end
-
-    def require_confirmation_type(worker_name)
-      if require_confirm.include?(worker_name)
-        'confirm'
-      elsif require_confirm_prompt.include?(worker_name)
-        'prompt'
-      end
+    def require_confirmation?(worker_name)
+      require_confirm.include?(worker_name)
     end
 
     def strategy

--- a/lib/sidekiq_adhoc_job.rb
+++ b/lib/sidekiq_adhoc_job.rb
@@ -44,8 +44,9 @@ module SidekiqAdhocJob
     attr_accessor :load_paths,
                   :module_names,
                   :strategy_name,
-                  :require_confirm_worker_names,
-                  :require_confirm_prompt_message
+                  :require_confirm_worker_names
+
+    attr_reader :require_confirm_prompt_message
 
     def initialize
       @load_paths = []
@@ -59,6 +60,12 @@ module SidekiqAdhocJob
 
     def require_confirm
       @require_confirm ||= Array(@require_confirm_worker_names).map(&:to_s)
+    end
+
+    def require_confirm_prompt_message=(message)
+      raise 'require_confirm_prompt_message must be string' unless message.is_a? String
+
+      @require_confirm_prompt_message = message
     end
 
     def require_confirmation?(worker_name)

--- a/lib/sidekiq_adhoc_job.rb
+++ b/lib/sidekiq_adhoc_job.rb
@@ -52,6 +52,7 @@ module SidekiqAdhocJob
       @load_paths = []
       @module_names = []
       @strategy_name = :default
+      @require_confirm_prompt_message = 'confirm'
     end
 
     def module_names

--- a/lib/sidekiq_adhoc_job/web/job_presenter.rb
+++ b/lib/sidekiq_adhoc_job/web/job_presenter.rb
@@ -53,7 +53,7 @@ module SidekiqAdhocJob
         queue = SidekiqAdhocJob.config.strategy.get_queue_name(klass_name)
         class_inspector = SidekiqAdhocJob::Utils::ClassInspector.new(klass_name)
         args = class_inspector.parameters(:perform)
-        require_confirm = SidekiqAdhocJob.config.require_confirmation_type(klass_name.to_s)
+        require_confirm = SidekiqAdhocJob.config.require_confirmation?(klass_name.to_s)
         new(klass_name, path_name, queue, args, require_confirm)
       end
 

--- a/lib/sidekiq_adhoc_job/web/job_presenter.rb
+++ b/lib/sidekiq_adhoc_job/web/job_presenter.rb
@@ -12,7 +12,8 @@ module SidekiqAdhocJob
                   :required_kw_args,
                   :optional_kw_args,
                   :has_rest_args,
-                  :require_confirm
+                  :require_confirm,
+                  :confirm_prompt_message
 
       StringUtil ||= ::SidekiqAdhocJob::Utils::String
 
@@ -27,6 +28,7 @@ module SidekiqAdhocJob
         @optional_kw_args = args[:key] || []
         @has_rest_args = !!args[:rest]
         @require_confirm = require_confirm
+        @confirm_prompt_message = SidekiqAdhocJob.config.require_confirm_prompt_message
       end
 
       # Builds the presenter instances for the schedule hash
@@ -51,7 +53,7 @@ module SidekiqAdhocJob
         queue = SidekiqAdhocJob.config.strategy.get_queue_name(klass_name)
         class_inspector = SidekiqAdhocJob::Utils::ClassInspector.new(klass_name)
         args = class_inspector.parameters(:perform)
-        require_confirm = SidekiqAdhocJob.config.require_confirmation?(klass_name.to_s)
+        require_confirm = SidekiqAdhocJob.config.require_confirmation_type(klass_name.to_s)
         new(klass_name, path_name, queue, args, require_confirm)
       end
 

--- a/lib/sidekiq_adhoc_job/web/templates/jobs/show.html.erb
+++ b/lib/sidekiq_adhoc_job/web/templates/jobs/show.html.erb
@@ -56,10 +56,18 @@
   </div>
 </form>
 
-<% if @presented_job.require_confirm %>
+<% if @presented_job.require_confirm == 'confirm' %>
   <script>
     document.getElementById('adhoc-jobs-submit-form').addEventListener('submit', (event) => {
       if (!confirm('Are you sure?'))
+        event.preventDefault();
+    })
+  </script>
+<% elsif @presented_job.require_confirm == 'prompt' %>
+  <script>
+    document.getElementById('adhoc-jobs-submit-form').addEventListener('submit', (event) => {
+      const confirmPrompt = "<%= @presented_job.confirm_prompt_message %>";
+      if (prompt(`Please enter "${confirmPrompt}" to confirm`) !== confirmPrompt)
         event.preventDefault();
     })
   </script>

--- a/lib/sidekiq_adhoc_job/web/templates/jobs/show.html.erb
+++ b/lib/sidekiq_adhoc_job/web/templates/jobs/show.html.erb
@@ -56,14 +56,7 @@
   </div>
 </form>
 
-<% if @presented_job.require_confirm == 'confirm' %>
-  <script>
-    document.getElementById('adhoc-jobs-submit-form').addEventListener('submit', (event) => {
-      if (!confirm('Are you sure?'))
-        event.preventDefault();
-    })
-  </script>
-<% elsif @presented_job.require_confirm == 'prompt' %>
+<% if @presented_job.require_confirm %>
   <script>
     document.getElementById('adhoc-jobs-submit-form').addEventListener('submit', (event) => {
       const confirmPrompt = "<%= @presented_job.confirm_prompt_message %>";

--- a/spec/sidekiq_adhoc_job/requests/jobs/index_spec.rb
+++ b/spec/sidekiq_adhoc_job/requests/jobs/index_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'GET /adhoc_jobs' do
         <td>type</td>
         <td>dryrun</td>
         <td>false</td>
-        <td>prompt</td>
+        <td>true</td>
         <td class="text-center">
           <a class="btn btn-warn btn-xs" href="/adhoc-jobs/sidekiq_adhoc_job_test_dummy_worker">
             View Job

--- a/spec/sidekiq_adhoc_job/requests/jobs/index_spec.rb
+++ b/spec/sidekiq_adhoc_job/requests/jobs/index_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'GET /adhoc_jobs' do
         <td>type</td>
         <td>dryrun</td>
         <td>false</td>
-        <td>false</td>
+        <td>prompt</td>
         <td class="text-center">
           <a class="btn btn-warn btn-xs" href="/adhoc-jobs/sidekiq_adhoc_job_test_dummy_worker">
             View Job

--- a/spec/sidekiq_adhoc_job/web/job_presenter_spec.rb
+++ b/spec/sidekiq_adhoc_job/web/job_presenter_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe SidekiqAdhocJob::Web::JobPresenter do
         expect(job_presenter.required_kw_args).to eq %i(type)
         expect(job_presenter.optional_kw_args).to eq %i(dryrun)
         expect(job_presenter.has_rest_args).to eq false
-        expect(job_presenter.require_confirm).to eq false
+        expect(job_presenter.require_confirm).to eq 'prompt'
 
         job_presenter = subject.find('sidekiq_adhoc_job_test_namespaced_worker')
         expect(job_presenter.name).to eq SidekiqAdhocJob::Test::NamespacedWorker
@@ -35,7 +35,7 @@ RSpec.describe SidekiqAdhocJob::Web::JobPresenter do
         expect(job_presenter.required_kw_args).to eq %i()
         expect(job_presenter.optional_kw_args).to eq %i()
         expect(job_presenter.has_rest_args).to eq false
-        expect(job_presenter.require_confirm).to eq true
+        expect(job_presenter.require_confirm).to eq 'confirm'
 
         job_presenter = subject.find('sidekiq_adhoc_job_test_worker_nested_namespaced_worker')
         expect(job_presenter.name).to eq SidekiqAdhocJob::Test::Worker::NestedNamespacedWorker
@@ -46,7 +46,7 @@ RSpec.describe SidekiqAdhocJob::Web::JobPresenter do
         expect(job_presenter.required_kw_args).to eq %i()
         expect(job_presenter.optional_kw_args).to eq %i()
         expect(job_presenter.has_rest_args).to eq false
-        expect(job_presenter.require_confirm).to eq false
+        expect(job_presenter.require_confirm).to eq nil
 
         job_presenter = subject.find('sidekiq_adhoc_job_test_dummy_rest_args_worker')
         expect(job_presenter.name).to eq SidekiqAdhocJob::Test::DummyRestArgsWorker
@@ -57,7 +57,7 @@ RSpec.describe SidekiqAdhocJob::Web::JobPresenter do
         expect(job_presenter.required_kw_args).to eq %i()
         expect(job_presenter.optional_kw_args).to eq %i()
         expect(job_presenter.has_rest_args).to eq true
-        expect(job_presenter.require_confirm).to eq false
+        expect(job_presenter.require_confirm).to eq nil
 
         job_presenter = subject.find('sidekiq_adhoc_job_test_prepended_worker')
         expect(job_presenter.name).to eq SidekiqAdhocJob::Test::PrependedWorker
@@ -68,7 +68,7 @@ RSpec.describe SidekiqAdhocJob::Web::JobPresenter do
         expect(job_presenter.required_kw_args).to eq %i()
         expect(job_presenter.optional_kw_args).to eq %i()
         expect(job_presenter.has_rest_args).to eq false
-        expect(job_presenter.require_confirm).to eq false
+        expect(job_presenter.require_confirm).to eq nil
 
         job_presenter = subject.find('sidekiq_adhoc_job_test_nested_prepended_worker')
         expect(job_presenter.name).to eq SidekiqAdhocJob::Test::NestedPrependedWorker
@@ -79,7 +79,7 @@ RSpec.describe SidekiqAdhocJob::Web::JobPresenter do
         expect(job_presenter.required_kw_args).to eq %i()
         expect(job_presenter.optional_kw_args).to eq %i()
         expect(job_presenter.has_rest_args).to eq false
-        expect(job_presenter.require_confirm).to eq false
+        expect(job_presenter.require_confirm).to eq nil
 
         job_presenter = subject.find('sidekiq_adhoc_job_test_sample_csv_worker')
         expect(job_presenter.name).to eq SidekiqAdhocJob::Test::SampleCSVWorker
@@ -90,7 +90,7 @@ RSpec.describe SidekiqAdhocJob::Web::JobPresenter do
         expect(job_presenter.required_kw_args).to eq %i()
         expect(job_presenter.optional_kw_args).to eq %i()
         expect(job_presenter.has_rest_args).to eq false
-        expect(job_presenter.require_confirm).to eq true
+        expect(job_presenter.require_confirm).to eq 'confirm'
 
         job_presenter = subject.find('sidekiq_adhoc_job_test_non_explicit')
         expect(job_presenter.name).to eq SidekiqAdhocJob::Test::NonExplicit
@@ -101,7 +101,7 @@ RSpec.describe SidekiqAdhocJob::Web::JobPresenter do
         expect(job_presenter.required_kw_args).to eq %i()
         expect(job_presenter.optional_kw_args).to eq %i()
         expect(job_presenter.has_rest_args).to eq false
-        expect(job_presenter.require_confirm).to eq false
+        expect(job_presenter.require_confirm).to eq nil
       end
     end
 

--- a/spec/sidekiq_adhoc_job/web/job_presenter_spec.rb
+++ b/spec/sidekiq_adhoc_job/web/job_presenter_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe SidekiqAdhocJob::Web::JobPresenter do
         expect(job_presenter.required_kw_args).to eq %i(type)
         expect(job_presenter.optional_kw_args).to eq %i(dryrun)
         expect(job_presenter.has_rest_args).to eq false
-        expect(job_presenter.require_confirm).to eq 'prompt'
+        expect(job_presenter.require_confirm).to eq true
 
         job_presenter = subject.find('sidekiq_adhoc_job_test_namespaced_worker')
         expect(job_presenter.name).to eq SidekiqAdhocJob::Test::NamespacedWorker
@@ -35,7 +35,7 @@ RSpec.describe SidekiqAdhocJob::Web::JobPresenter do
         expect(job_presenter.required_kw_args).to eq %i()
         expect(job_presenter.optional_kw_args).to eq %i()
         expect(job_presenter.has_rest_args).to eq false
-        expect(job_presenter.require_confirm).to eq 'confirm'
+        expect(job_presenter.require_confirm).to eq true
 
         job_presenter = subject.find('sidekiq_adhoc_job_test_worker_nested_namespaced_worker')
         expect(job_presenter.name).to eq SidekiqAdhocJob::Test::Worker::NestedNamespacedWorker
@@ -46,7 +46,7 @@ RSpec.describe SidekiqAdhocJob::Web::JobPresenter do
         expect(job_presenter.required_kw_args).to eq %i()
         expect(job_presenter.optional_kw_args).to eq %i()
         expect(job_presenter.has_rest_args).to eq false
-        expect(job_presenter.require_confirm).to eq nil
+        expect(job_presenter.require_confirm).to eq false
 
         job_presenter = subject.find('sidekiq_adhoc_job_test_dummy_rest_args_worker')
         expect(job_presenter.name).to eq SidekiqAdhocJob::Test::DummyRestArgsWorker
@@ -57,7 +57,7 @@ RSpec.describe SidekiqAdhocJob::Web::JobPresenter do
         expect(job_presenter.required_kw_args).to eq %i()
         expect(job_presenter.optional_kw_args).to eq %i()
         expect(job_presenter.has_rest_args).to eq true
-        expect(job_presenter.require_confirm).to eq nil
+        expect(job_presenter.require_confirm).to eq false
 
         job_presenter = subject.find('sidekiq_adhoc_job_test_prepended_worker')
         expect(job_presenter.name).to eq SidekiqAdhocJob::Test::PrependedWorker
@@ -68,7 +68,7 @@ RSpec.describe SidekiqAdhocJob::Web::JobPresenter do
         expect(job_presenter.required_kw_args).to eq %i()
         expect(job_presenter.optional_kw_args).to eq %i()
         expect(job_presenter.has_rest_args).to eq false
-        expect(job_presenter.require_confirm).to eq nil
+        expect(job_presenter.require_confirm).to eq false
 
         job_presenter = subject.find('sidekiq_adhoc_job_test_nested_prepended_worker')
         expect(job_presenter.name).to eq SidekiqAdhocJob::Test::NestedPrependedWorker
@@ -79,7 +79,7 @@ RSpec.describe SidekiqAdhocJob::Web::JobPresenter do
         expect(job_presenter.required_kw_args).to eq %i()
         expect(job_presenter.optional_kw_args).to eq %i()
         expect(job_presenter.has_rest_args).to eq false
-        expect(job_presenter.require_confirm).to eq nil
+        expect(job_presenter.require_confirm).to eq false
 
         job_presenter = subject.find('sidekiq_adhoc_job_test_sample_csv_worker')
         expect(job_presenter.name).to eq SidekiqAdhocJob::Test::SampleCSVWorker
@@ -90,7 +90,7 @@ RSpec.describe SidekiqAdhocJob::Web::JobPresenter do
         expect(job_presenter.required_kw_args).to eq %i()
         expect(job_presenter.optional_kw_args).to eq %i()
         expect(job_presenter.has_rest_args).to eq false
-        expect(job_presenter.require_confirm).to eq 'confirm'
+        expect(job_presenter.require_confirm).to eq true
 
         job_presenter = subject.find('sidekiq_adhoc_job_test_non_explicit')
         expect(job_presenter.name).to eq SidekiqAdhocJob::Test::NonExplicit
@@ -101,7 +101,7 @@ RSpec.describe SidekiqAdhocJob::Web::JobPresenter do
         expect(job_presenter.required_kw_args).to eq %i()
         expect(job_presenter.optional_kw_args).to eq %i()
         expect(job_presenter.has_rest_args).to eq false
-        expect(job_presenter.require_confirm).to eq nil
+        expect(job_presenter.require_confirm).to eq false
       end
     end
 

--- a/spec/sidekiq_adhoc_job_spec.rb
+++ b/spec/sidekiq_adhoc_job_spec.rb
@@ -16,6 +16,16 @@ RSpec.describe SidekiqAdhocJob do
     it 'yields configuration object' do
       expect { |blk| subject.configure(&blk) }.to yield_with_args(instance_of(SidekiqAdhocJob::Configuration))
     end
+
+    context 'when require_confirm_prompt_message is not string' do
+      subject do
+        described_class.configure { |config| config.require_confirm_prompt_message = {'not' => %w[a string] } }
+      end
+
+      it 'raises error' do
+        expect { subject }.to raise_error 'require_confirm_prompt_message must be string'
+      end
+    end
   end
 
   describe '.config' do

--- a/spec/support/sidekiq_adhoc_job_setup.rb
+++ b/spec/support/sidekiq_adhoc_job_setup.rb
@@ -4,10 +4,14 @@ RSpec.shared_context 'SidekiqAdhocJob setup' do
   before do
     SidekiqAdhocJob.configure do |config|
       config.module_names = [:'SidekiqAdhocJob::Test', :'SidekiqAdhocJob::Test::Worker']
-      config.require_confirm_worker_names = 
+      config.require_confirm_worker_names =
         %w[
           SidekiqAdhocJob::Test::NamespacedWorker
           SidekiqAdhocJob::Test::SampleCSVWorker
+        ]
+      config.require_confirm_prompt_worker_names =
+        %w[
+          SidekiqAdhocJob::Test::DummyWorker
         ]
     end
     SidekiqAdhocJob.init

--- a/spec/support/sidekiq_adhoc_job_setup.rb
+++ b/spec/support/sidekiq_adhoc_job_setup.rb
@@ -8,9 +8,6 @@ RSpec.shared_context 'SidekiqAdhocJob setup' do
         %w[
           SidekiqAdhocJob::Test::NamespacedWorker
           SidekiqAdhocJob::Test::SampleCSVWorker
-        ]
-      config.require_confirm_prompt_worker_names =
-        %w[
           SidekiqAdhocJob::Test::DummyWorker
         ]
     end


### PR DESCRIPTION
## Background
Need to require more attention when confirming to run a job, for an extra assurance that very critical jobs won't be triggered by mistake.

## What's this change
- Change confirmation method from clicking 'OK' button to typing a challenge keyword
- Add option `require_confirm_prompt_message`: The keyword for the confirmation (preferably an environment variable)
<img width="1193" alt="image" src="https://user-images.githubusercontent.com/99305093/172749926-ce4910af-1eae-4bcf-984a-9d593eb18509.png">

### Running confirmation required job
Requires user to type a challenge keyword
<img width="1238" alt="image" src="https://user-images.githubusercontent.com/99305093/169796420-53e784be-eb52-4a95-91a0-8f0b519db2ef.png">