### PR TITLE
Bump sidekiq support to version 7

### DIFF
--- a/sidekiq_adhoc_job.gemspec
+++ b/sidekiq_adhoc_job.gemspec
@@ -32,5 +32,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rack-test', '~> 1.1.0'
   spec.add_development_dependency 'mock_redis', '~> 0.26.0'
 
-  spec.add_runtime_dependency 'sidekiq', '< 7'
+  spec.add_runtime_dependency 'sidekiq', '< 8'
 end


### PR DESCRIPTION
Due to a [CVE](https://github.com/Kaligo/jenkins-pipeline-libraries/pull/513) found in Sidekiq 6, Ascenda is working on upgrading to version 7. 

As a bonus, this would be tested by some apps on Ascenda using your gem @gohkhoonhiang  :)