### PR TITLE
[Fix #28] Check if the method has super method

### DIFF
--- a/lib/sidekiq_adhoc_job/utils/class_inspector.rb
+++ b/lib/sidekiq_adhoc_job/utils/class_inspector.rb
@@ -48,7 +48,7 @@ module SidekiqAdhocJob
       end
 
       def klass_method(method)
-        return method if method.owner == klass_name
+        return method if method.owner == klass_name || !method.super_method
 
         klass_method(method.super_method)
       end

--- a/spec/sidekiq_adhoc_job/utils/class_inspector_spec.rb
+++ b/spec/sidekiq_adhoc_job/utils/class_inspector_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe SidekiqAdhocJob::Utils::ClassInspector do
     end
   end
 
-  context 'with an inherited class without redefining method' do
+  context "with an inherited class without redefining method" do
     before do
       stub_const("TempWorker", Class.new(SidekiqAdhocJob::Test::DummyWorker))
     end

--- a/spec/sidekiq_adhoc_job/utils/class_inspector_spec.rb
+++ b/spec/sidekiq_adhoc_job/utils/class_inspector_spec.rb
@@ -41,4 +41,23 @@ RSpec.describe SidekiqAdhocJob::Utils::ClassInspector do
       end
     end
   end
+
+  context 'with an inherited class without redefining method' do
+    before do
+      stub_const("TempWorker", Class.new(SidekiqAdhocJob::Test::DummyWorker))
+    end
+
+    let(:klass) { TempWorker }
+
+    describe "#parameters" do
+      it "returns the parameters of the parent method" do
+        expect(inspector.parameters(:perform)).to eq({
+          key: [:dryrun],
+          keyreq: [:type],
+          opt: [:retry_job, :retries, :interval, :name, :options],
+          req: [:id, :overwrite]
+        })
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fix https://github.com/gohkhoonhiang/sidekiq_adhoc_job/issues/28

This can be reproduced and verified by:

```ruby

class DummyWorker
  include Sidekiq::Worker

  def perform(id)
  end
end

class DummyWorker2 < DummyWorker
end

class_inspector = SidekiqAdhocJob::Utils::ClassInspector.new(DummyWorker2)
args = class_inspector.parameters(:perform)
```

```
NoMethodError: undefined method 'owner' for nil (NoMethodError)

        return method if method.owner == klass_name
                               ^^^^^^
```